### PR TITLE
Redesign Outreach: list, detail, and log-activity

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -420,6 +420,12 @@ hr.h-rule {
   border-color: var(--ink);
 }
 
+.status-pill-count {
+  margin-left: 6px;
+  font-size: 9px;
+  opacity: .7;
+}
+
 /* =============================================================================
    Cards (no rounded corners, divider style)
    ============================================================================= */
@@ -451,6 +457,66 @@ hr.h-rule {
   text-transform: uppercase;
   color: var(--ink-faint);
   margin-top: 4px;
+}
+
+.outreach-card {
+  padding: 18px 22px;
+}
+
+.card-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 10px;
+}
+
+.card-subtitle {
+  font-family: var(--font-ui);
+  font-size: 10px;
+  letter-spacing: .18em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin-top: 4px;
+}
+
+.card-next-step {
+  margin-top: 12px;
+  padding-left: 12px;
+  border-left: 2px solid var(--accent);
+}
+
+.card-next-step-overdue {
+  border-left-color: var(--warning);
+}
+
+.card-next-step-eyebrow {
+  font-family: var(--font-ui);
+  font-size: 10px;
+  letter-spacing: .22em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin-bottom: 2px;
+}
+
+.card-next-step-overdue .card-next-step-eyebrow {
+  color: var(--warning);
+}
+
+.card-next-step-body {
+  font-family: var(--font-body);
+  font-size: 15px;
+  font-style: italic;
+  line-height: 1.35;
+  color: var(--ink);
+}
+
+.card-contact {
+  margin-top: 12px;
+  font-family: var(--font-ui);
+  font-size: 10px;
+  letter-spacing: .18em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
 }
 
 /* =============================================================================
@@ -675,10 +741,42 @@ main[role="main"] {
   border-top: 1px solid var(--warning);
   border-bottom: 1px solid var(--warning);
   background: color-mix(in oklab, var(--warning-soft) 50%, var(--paper));
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  color: var(--ink);
+}
+
+.callout-numeral {
   font-family: var(--font-display);
   font-style: italic;
-  font-size: 15px;
-  color: var(--ink);
+  font-size: 32px;
+  color: var(--warning);
+  line-height: .8;
+  flex-shrink: 0;
+}
+
+.callout-body {
+  flex: 1;
+}
+
+.callout-headline {
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: 17px;
+  line-height: 1.2;
+}
+
+.callout-sub {
+  margin-top: 2px;
+}
+
+.callout-action {
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: 14px;
+  color: var(--warning);
+  white-space: nowrap;
 }
 
 /* =============================================================================
@@ -748,6 +846,7 @@ main[role="main"] {
 
 .filter-toggle {
   display: flex;
+  align-items: center;
   padding: 16px 22px 10px;
   border-bottom: 1px solid var(--rule-soft);
 }
@@ -758,7 +857,7 @@ main[role="main"] {
   letter-spacing: .18em;
   text-transform: uppercase;
   font-weight: 500;
-  padding: 6px 14px 6px 0;
+  padding: 6px 0;
   margin-right: 18px;
   background: transparent;
   border: none;
@@ -770,6 +869,15 @@ main[role="main"] {
 .filter-toggle-btn.active {
   color: var(--ink);
   border-bottom-color: var(--accent);
+}
+
+.filter-toggle-count {
+  margin-left: auto;
+  font-family: var(--font-ui);
+  font-size: 10px;
+  letter-spacing: .18em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
 }
 
 /* =============================================================================
@@ -845,6 +953,320 @@ main[role="main"] {
 
 .modal-body {
   padding: 22px;
+}
+
+/* =============================================================================
+   Detail screen (Outreach facility, Schedule gig)
+   ============================================================================= */
+
+.detail-topbar {
+  padding: 14px 22px;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  border-bottom: 1px solid var(--rule);
+  background: var(--paper);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.topbar-link {
+  font-family: var(--font-ui);
+  font-size: 10px;
+  letter-spacing: .18em;
+  text-transform: uppercase;
+  font-weight: 500;
+  background: none;
+  border: none;
+  color: var(--ink-faint);
+  cursor: pointer;
+  padding: 0;
+}
+
+.topbar-link-accent {
+  color: var(--accent-deep);
+}
+
+.detail-body {
+  padding-bottom: 80px;
+}
+
+.detail-hero {
+  padding: 18px 22px 18px;
+}
+
+.detail-eyebrow {
+  margin-bottom: 6px;
+}
+
+.detail-title {
+  font-family: var(--font-display);
+  font-size: 30px;
+  font-weight: 500;
+  font-style: italic;
+  margin: 0;
+  line-height: 1.05;
+  color: var(--ink);
+}
+
+.detail-status-row {
+  margin-top: 14px;
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.detail-next-action {
+  padding: 16px 22px 18px;
+  background: var(--paper-2);
+  border-bottom: 1px solid var(--rule);
+}
+
+.detail-next-eyebrow {
+  margin-bottom: 4px;
+}
+
+.detail-next-eyebrow.is-overdue {
+  color: var(--warning);
+}
+
+.detail-next-body {
+  font-family: var(--font-display);
+  font-size: 19px;
+  font-style: italic;
+  line-height: 1.3;
+  color: var(--ink);
+}
+
+.detail-next-cta {
+  margin-top: 12px;
+  width: 100%;
+}
+
+.detail-section {
+  padding: 18px 22px;
+}
+
+.detail-section-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 10px;
+}
+
+.detail-section-action {
+  font-family: var(--font-ui);
+  font-size: 10px;
+  letter-spacing: .18em;
+  text-transform: uppercase;
+  font-weight: 500;
+  background: none;
+  border: none;
+  color: var(--accent-deep);
+  cursor: pointer;
+  padding: 0;
+}
+
+.detail-empty {
+  font-family: var(--font-body);
+  font-style: italic;
+  color: var(--ink-faint);
+  font-size: 14px;
+  padding: 6px 0;
+}
+
+.detail-contact {
+  padding: 10px 0;
+  border-bottom: 1px dotted var(--rule-soft);
+  cursor: pointer;
+}
+
+.detail-contact:last-child {
+  border-bottom: none;
+}
+
+.detail-contact-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.detail-contact-name {
+  font-family: var(--font-display);
+  font-size: 17px;
+  color: var(--ink);
+}
+
+.detail-contact-meta {
+  margin-top: 4px;
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  flex-wrap: wrap;
+}
+
+.detail-contact-phone {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--accent-deep);
+}
+
+.detail-contact-email {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--accent-deep);
+  word-break: break-all;
+}
+
+.detail-contact-meta .meta-sep {
+  color: var(--ink-faint);
+}
+
+.detail-timeline-row {
+  display: flex;
+  gap: 14px;
+  margin-bottom: 16px;
+}
+
+.detail-timeline-date {
+  width: 56px;
+  flex-shrink: 0;
+  text-align: right;
+}
+
+.detail-timeline-type {
+  color: var(--accent);
+  margin-top: 2px;
+  font-size: 9px;
+}
+
+.detail-timeline-rule {
+  width: 1px;
+  background: var(--rule);
+  position: relative;
+  flex-shrink: 0;
+}
+
+.detail-timeline-rule .dot {
+  position: absolute;
+  left: -3px;
+  top: 4px;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--paper);
+  border: 1px solid var(--accent);
+}
+
+.detail-timeline-note {
+  flex: 1;
+  font-family: var(--font-body);
+  font-size: 14.5px;
+  line-height: 1.4;
+  color: var(--ink);
+}
+
+.detail-notes {
+  font-family: var(--font-body);
+  font-style: italic;
+  font-size: 15px;
+  line-height: 1.5;
+  color: var(--ink-soft);
+}
+
+/* =============================================================================
+   Form layouts (manuscript style — borderless, italic, smcaps labels)
+   ============================================================================= */
+
+.form-topbar {
+  padding: 14px 22px;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  border-bottom: 1px solid var(--rule);
+  background: var(--paper);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.form-body {
+  padding: 18px 22px 80px;
+}
+
+.form-title {
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: 24px;
+  font-weight: 500;
+  margin: 4px 0 22px;
+  line-height: 1.1;
+  color: var(--ink);
+}
+
+.form-eyebrow-label {
+  display: block;
+  margin-bottom: 8px;
+  margin-top: 22px;
+}
+
+.form-eyebrow-label:first-of-type {
+  margin-top: 0;
+}
+
+.form-pill-row {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-bottom: 4px;
+}
+
+.activity-type-btn {
+  background: transparent;
+  cursor: pointer;
+  font-family: var(--font-ui);
+}
+
+.form-input-display {
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: 18px;
+}
+
+.form-input-italic {
+  font-style: italic;
+  font-size: 15px;
+  color: var(--ink-soft);
+}
+
+.form-select-bare {
+  background-position: right 4px center;
+}
+
+.form-next-step-block {
+  margin-top: 26px;
+  padding: 16px;
+  border: 1px solid var(--rule);
+  background: var(--paper-2);
+}
+
+.form-next-step-eyebrow {
+  color: var(--accent-deep);
+  margin-bottom: 8px;
+}
+
+.form-next-step-due-label {
+  display: block;
+  margin-top: 12px;
+  margin-bottom: 4px;
+  font-size: 9px;
+}
+
+.form-submit {
+  margin-top: 22px;
+  width: 100%;
 }
 
 /* =============================================================================

--- a/js/app.js
+++ b/js/app.js
@@ -137,18 +137,37 @@ TSEB.util.isSoon = function(d) {
   return dt >= now && dt <= week;
 };
 
+TSEB.util.STATUS_LABELS = {
+  initial_contact: 'Initial',
+  in_conversation: 'Talking',
+  site_visit: 'Site Visit',
+  active: 'Active',
+  on_hold: 'Hold',
+  previous: 'Previous',
+  inactive: 'Inactive'
+};
+
+TSEB.util.statusLabel = function(status) {
+  return TSEB.util.STATUS_LABELS[status] ||
+    (status || '').replace(/_/g, ' ').replace(/\b\w/g, function(c) { return c.toUpperCase(); });
+};
+
+// Render a manuscript status pill. opts.compact=true drops the border for inline use.
+// opts.active=true inverts the pill (ink fill, paper text). opts.attrs adds raw HTML attrs.
+TSEB.util.statusPill = function(status, opts) {
+  opts = opts || {};
+  const label = TSEB.util.statusLabel(status);
+  const cls = ['status-pill'];
+  if (opts.active) cls.push('is-active');
+  const style = opts.compact ? ' style="border-color:transparent; padding:2px 0; font-size:9px;"' : '';
+  const attrs = opts.attrs ? ' ' + opts.attrs : '';
+  return '<span class="' + cls.join(' ') + '" data-status="' + status + '"' + style + attrs +
+    '><span class="dot"></span>' + TSEB.util.esc(label) + '</span>';
+};
+
+// Legacy alias — prefer statusPill in new code.
 TSEB.util.statusBadge = function(status) {
-  const map = {
-    active: 'badge-active',
-    initial_contact: 'badge-initial',
-    in_conversation: 'badge-conversation',
-    site_visit: 'badge-conversation',
-    on_hold: 'badge-muted',
-    previous: 'badge-muted',
-    inactive: 'badge-overdue'
-  };
-  const label = (status || '').replace(/_/g, ' ').replace(/\b\w/g, function(c) { return c.toUpperCase(); });
-  return '<span class="badge ' + (map[status] || 'badge-muted') + '">' + label + '</span>';
+  return TSEB.util.statusPill(status);
 };
 
 TSEB.util.fmtTime = function(t) {

--- a/js/outreach.js
+++ b/js/outreach.js
@@ -28,9 +28,11 @@ TSEB.outreach = {
   _renderFilter() {
     const el = document.getElementById('outreach-filter');
     if (!el) return;
+    const data = this._filtered();
     el.innerHTML =
-      '<button class="filter-toggle-btn' + (this._filter === 'all' ? ' active' : '') + '" onclick="TSEB.outreach.setFilter(\'all\')">All</button>' +
-      '<button class="filter-toggle-btn' + (this._filter === 'mine' ? ' active' : '') + '" onclick="TSEB.outreach.setFilter(\'mine\')">Mine</button>';
+      '<button class="filter-toggle-btn' + (this._filter === 'all' ? ' active' : '') + '" onclick="TSEB.outreach.setFilter(\'all\')">All facilities</button>' +
+      '<button class="filter-toggle-btn' + (this._filter === 'mine' ? ' active' : '') + '" onclick="TSEB.outreach.setFilter(\'mine\')">Mine</button>' +
+      '<span class="filter-toggle-count">' + data.length + '</span>';
   },
 
   setFilter(val) {
@@ -60,6 +62,7 @@ TSEB.outreach = {
     } else {
       this._statusFilter = (this._statusFilter === status) ? null : status;
     }
+    this._renderFilter();
     this._renderPills();
     this._renderCards();
     this._renderCallout();
@@ -88,14 +91,15 @@ TSEB.outreach = {
     }
 
     el.style.display = '';
-    const parts = [];
-    if (overdue.length > 0) {
-      parts.push('<strong style="color:var(--error);">' + overdue.length + ' overdue</strong>');
-    }
-    if (soon.length > 0) {
-      parts.push('<strong style="color:var(--warning);">' + soon.length + ' due this week</strong>');
-    }
-    el.innerHTML = 'Follow-up needed: ' + parts.join(' · ');
+    const overdueCount = overdue.length;
+    const soonCount = soon.length;
+    el.innerHTML =
+      '<span class="callout-numeral">' + overdueCount + '</span>' +
+      '<div class="callout-body">' +
+        '<div class="callout-headline">overdue follow-up' + (overdueCount === 1 ? '' : 's') + '</div>' +
+        (soonCount > 0 ? '<div class="eyebrow callout-sub">+' + soonCount + ' due this week</div>' : '') +
+      '</div>' +
+      '<span class="callout-action">tend &rarr;</span>';
   },
 
   _renderPills() {
@@ -103,50 +107,23 @@ TSEB.outreach = {
     if (!el) return;
     const data = this._data || [];
 
-    const statusGroups = {
-      initial_contact: 0,
-      in_conversation: 0,
-      site_visit: 0,
-      active: 0,
-      on_hold: 0,
-      previous: 0,
-      inactive: 0
-    };
+    const order = ['initial_contact', 'in_conversation', 'site_visit', 'active', 'on_hold', 'previous', 'inactive'];
+    const counts = {};
+    order.forEach(function(k) { counts[k] = 0; });
     data.forEach(function(i) {
-      if (i.status in statusGroups) statusGroups[i.status]++;
+      if (i.status in counts) counts[i.status]++;
     });
 
-    const labels = {
-      initial_contact: 'Initial',
-      in_conversation: 'Talking',
-      site_visit: 'Site Visit',
-      active: 'Active',
-      on_hold: 'Hold',
-      previous: 'Previous',
-      inactive: 'Inactive'
-    };
-    const badgeClass = {
-      initial_contact: 'badge-initial',
-      in_conversation: 'badge-conversation',
-      site_visit: 'badge-conversation',
-      active: 'badge-active',
-      on_hold: 'badge-muted',
-      previous: 'badge-muted',
-      inactive: 'badge-overdue'
-    };
-
     var self = this;
-    el.innerHTML = Object.keys(statusGroups).map(function(key) {
-      var count = statusGroups[key];
-      if (count === 0) return '';
-      var isActive = self._statusFilter === key;
-      var activeStyle = isActive ? 'outline:3px solid var(--primary); outline-offset:1px; font-weight:700;' : '';
-      return '<span class="badge ' + (badgeClass[key] || 'badge-muted') + '" ' +
-        'style="cursor:pointer; ' + activeStyle + '" ' +
+    el.innerHTML = order.map(function(key) {
+      if (counts[key] === 0) return '';
+      const isActive = self._statusFilter === key;
+      const label = TSEB.util.statusLabel(key);
+      return '<span class="status-pill' + (isActive ? ' is-active' : '') + '" data-status="' + key + '" ' +
         'onclick="TSEB.outreach.setStatusFilter(\'' + key + '\')">' +
-        labels[key] + ' · ' + count + '</span>';
-    }).join('') +
-    (self._statusFilter ? ' <span style="font-size:13px; color:var(--primary); cursor:pointer; text-decoration:underline;" onclick="TSEB.outreach.setStatusFilter(null)">Clear filter</span>' : '');
+        '<span class="dot"></span>' + label +
+        '<span class="status-pill-count">' + counts[key] + '</span></span>';
+    }).join('');
   },
 
   _renderCards() {
@@ -183,42 +160,47 @@ TSEB.outreach = {
 
   _cardHTML(i) {
     const overdue = TSEB.util.isOverdue(i.next_step_due);
-    const soon = TSEB.util.isSoon(i.next_step_due);
-    const cardClass = 'card' + (overdue ? ' card-overdue' : '');
 
+    // Subtitle: "{type} · {city or address head} · {zip}"
+    const typeLabel = i.institution_type
+      ? i.institution_type.replace(/_/g, ' ').replace(/\b\w/g, function(c) { return c.toUpperCase(); })
+      : '';
+    const subtitleParts = [];
+    if (typeLabel) subtitleParts.push(TSEB.util.esc(typeLabel));
+    if (i.address) subtitleParts.push(TSEB.util.esc(i.address));
+    if (i.zip_code) subtitleParts.push(TSEB.util.esc(i.zip_code));
+    const subtitleHTML = subtitleParts.length
+      ? '<div class="card-subtitle">' + subtitleParts.join(' &middot; ') + '</div>'
+      : '';
+
+    // Next step block (italic body + accent left rule, warning if overdue)
     let nextStepHTML = '';
     if (i.next_step) {
-      const dateText = overdue ? 'Overdue' : (soon ? 'Due ' + TSEB.util.fmtDateShort(i.next_step_due) : TSEB.util.fmtDateShort(i.next_step_due));
-      const dateStyle = overdue ? 'color:var(--error); font-weight:700;' : (soon ? 'color:var(--warning); font-weight:600;' : 'color:var(--muted);');
-      nextStepHTML = '<div class="card-next-step">' +
-        '<span style="' + dateStyle + ' font-size:13px;">' + TSEB.util.esc(dateText) + '</span>' +
-        ' — ' + TSEB.util.esc(i.next_step) +
+      const dateText = overdue ? 'Overdue' : ('Due ' + TSEB.util.fmtDateShort(i.next_step_due));
+      nextStepHTML = '<div class="card-next-step' + (overdue ? ' card-next-step-overdue' : '') + '">' +
+        '<div class="card-next-step-eyebrow">Next &middot; ' + TSEB.util.esc(dateText) + '</div>' +
+        '<div class="card-next-step-body">' + TSEB.util.esc(i.next_step) + '</div>' +
         '</div>';
     }
 
-    const outreacherHTML = i.outreacher
-      ? '<span style="margin-right:8px;">' + TSEB.util.singerChip(i.outreacher.first_name) + '</span>'
-      : '';
-
-    // Primary contact
+    // Primary contact (smcaps "↳ Name")
     var primary = (i.contacts || []).find(function(c) { return c.is_primary; }) || (i.contacts || [])[0];
     var contactLine = '';
     if (primary) {
       var cName = ((primary.first_name || '') + ' ' + (primary.last_name || '')).trim();
-      contactLine = '<div class="card-detail">' + TSEB.util.esc(cName) +
-        (primary.phone ? ' · <a href="tel:' + TSEB.util.esc(primary.phone) + '" style="color:var(--primary);" onclick="event.stopPropagation();">' + TSEB.util.esc(primary.phone) + '</a>' : '') +
-        '</div>';
+      if (cName) {
+        contactLine = '<div class="card-contact">&#8627; ' + TSEB.util.esc(cName) + '</div>';
+      }
     }
 
-    return '<div class="' + cardClass + '" style="cursor:pointer;" onclick="TSEB.outreach.showDetail(\'' + i.id + '\')">' +
-      '<div style="display:flex; justify-content:space-between; align-items:flex-start; gap:8px; margin-bottom:6px;">' +
-      '<div class="card-title">' + TSEB.util.esc(i.name) + '</div>' +
-      TSEB.util.statusBadge(i.status) +
+    return '<div class="card outreach-card" onclick="TSEB.outreach.showDetail(\'' + i.id + '\')">' +
+      '<div class="card-head">' +
+      '<h3 class="card-title">' + TSEB.util.esc(i.name) + '</h3>' +
+      TSEB.util.statusPill(i.status, { compact: true }) +
       '</div>' +
-      (i.address || i.zip_code ? '<div class="card-detail">' + TSEB.util.esc(i.address || '') + (i.address && i.zip_code ? ' · ' : '') + (i.zip_code ? TSEB.util.esc(i.zip_code) : '') + '</div>' : '') +
-      contactLine +
+      subtitleHTML +
       nextStepHTML +
-      (outreacherHTML ? '<div style="margin-top:8px;">' + outreacherHTML + '</div>' : '') +
+      contactLine +
       '</div>';
   },
 
@@ -246,126 +228,127 @@ TSEB.outreach = {
       ? Math.floor((new Date() - new Date(inst.next_step_due)) / 86400000)
       : 0;
 
-    // Next step banner
-    let nextStepBanner = '';
-    if (inst.next_step) {
-      nextStepBanner = '<div style="background:' + (overdue ? 'var(--error-light)' : 'var(--accent-light)') + '; border-left:4px solid ' + (overdue ? 'var(--error)' : 'var(--accent)') + '; padding:14px 16px; border-radius:0 var(--radius-sm) var(--radius-sm) 0; margin-bottom:16px;">' +
-        '<div style="font-size:13px; font-weight:700; text-transform:uppercase; letter-spacing:.04em; color:' + (overdue ? 'var(--error)' : 'var(--warning)') + '; margin-bottom:4px;">Next Step</div>' +
-        '<div style="font-size:17px;">' + TSEB.util.esc(inst.next_step) + '</div>' +
-        '<div style="font-size:14px; color:var(--muted); margin-top:6px;">Due: ' + TSEB.util.fmtDate(inst.next_step_due) +
-        (overdue ? ' <strong style="color:var(--error);">· ' + daysOverdue + ' days overdue</strong>' : '') +
-        '</div></div>';
-    }
-
-    // Status change buttons
-    const allStatuses = [
-      { value: 'initial_contact', label: 'Initial Contact' },
-      { value: 'in_conversation', label: 'In Conversation' },
-      { value: 'site_visit', label: 'Site Visit' },
-      { value: 'active', label: 'Active' },
-      { value: 'on_hold', label: 'On Hold' },
-      { value: 'previous', label: 'Previous' },
-      { value: 'inactive', label: 'Inactive' }
-    ];
-    const statusButtons = allStatuses.map(function(s) {
-      const isCurrent = s.value === inst.status;
-      return '<button class="btn ' + (isCurrent ? 'btn-primary' : 'btn-secondary') + '" style="font-size:14px; min-height:40px; padding:8px 14px;' + (isCurrent ? ' cursor:default;' : '') + '" ' +
-        (isCurrent ? 'disabled' : 'onclick="TSEB.outreach.changeStatus(\'' + id + '\', \'' + s.value + '\')"') +
-        '>' + TSEB.util.esc(s.label) + '</button>';
-    }).join('');
-
-    // Contacts section
-    let contactsHTML = '<div style="margin-bottom:20px;">' +
-      '<div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:10px;">' +
-      '<h4 style="font-size:14px; font-weight:700; text-transform:uppercase; letter-spacing:.06em; color:var(--muted); margin:0;">Contacts</h4>' +
-      '<button class="btn btn-secondary" style="font-size:13px; min-height:36px; padding:6px 12px;" onclick="TSEB.outreach.openAddContact(\'' + id + '\')">+ Add Contact</button>' +
-      '</div>';
-    if (contacts && contacts.length) {
-      contactsHTML += contacts.map(function(c) {
-          return '<div style="background:var(--bg); border:1px solid var(--border); border-radius:var(--radius-sm); padding:12px; margin-bottom:8px;">' +
-            '<div style="display:flex; justify-content:space-between; align-items:flex-start;">' +
-            '<div><div style="font-weight:600; font-size:16px;">' + TSEB.util.esc((c.first_name || '') + ' ' + (c.last_name || '')).trim() +
-            (c.is_primary ? ' <span style="font-size:11px; color:var(--accent); font-weight:700;">PRIMARY</span>' : '') + '</div>' +
-            (c.job_title ? '<div style="font-size:14px; color:var(--muted);">' + TSEB.util.esc(c.job_title) + '</div>' : '') +
-            '<div style="font-size:14px; margin-top:4px;">' +
-            (c.phone ? '<a href="tel:' + TSEB.util.esc(c.phone) + '" style="color:var(--primary);">' + TSEB.util.esc(c.phone) + '</a>' : '') +
-            (c.phone && c.email ? ' · ' : '') +
-            (c.email ? '<a href="mailto:' + TSEB.util.esc(c.email) + '" style="color:var(--primary);">' + TSEB.util.esc(c.email) + '</a>' : '') +
-            '</div></div>' +
-            '<button class="btn btn-ghost" style="font-size:12px; min-height:32px; padding:4px 10px; align-self:flex-start;" onclick="event.stopPropagation(); TSEB.outreach.openEditContact(\'' + c.id + '\', \'' + id + '\')">Edit</button>' +
-            '</div></div>';
-        }).join('');
-    } else {
-      contactsHTML += '<p style="color:var(--muted); font-size:15px;">No contacts yet. Add one to track who to call.</p>';
-    }
-    contactsHTML += '</div>';
-
-    // Timeline section
-    let timelineHTML = '';
-    if (activities && activities.length) {
-      timelineHTML = activities.map(function(a) {
-        const isAction = ['phone_call','voicemail','email_sent','email_received','in_person','site_visit','first_sing'].includes(a.activity_type);
-        const isStatus = a.activity_type === 'status_change';
-        const dotColor = isStatus ? 'var(--info)' : isAction ? 'var(--primary)' : 'var(--muted)';
-        const typeLabel = (a.activity_type || '').replace(/_/g, ' ').replace(/\b\w/g, function(c) { return c.toUpperCase(); });
-        return '<div style="display:flex; gap:12px; margin-bottom:16px;">' +
-          '<div style="flex-shrink:0; width:10px; height:10px; border-radius:50%; background:' + dotColor + '; margin-top:6px;"></div>' +
-          '<div style="flex:1;">' +
-          '<div style="font-size:13px; color:var(--muted); margin-bottom:2px;">' +
-          TSEB.util.fmtDate(a.activity_date) +
-          (a.singer ? ' · ' + TSEB.util.esc(a.singer.first_name) : '') +
-          ' · <em>' + TSEB.util.esc(typeLabel) + '</em>' +
-          '</div>' +
-          '<div style="font-size:15px;">' + TSEB.util.esc(a.description) + '</div>' +
-          '</div></div>';
-      }).join('');
-    } else {
-      timelineHTML = '<p style="color:var(--muted); font-size:15px;">No activity logged yet. Tap Log Activity to get started.</p>';
-    }
-
     const typeLabel = inst.institution_type
       ? inst.institution_type.replace(/_/g, ' ').replace(/\b\w/g, function(c) { return c.toUpperCase(); })
       : '';
 
+    // Eyebrow line: type · address · zip
+    const eyebrowParts = [];
+    if (typeLabel) eyebrowParts.push(TSEB.util.esc(typeLabel));
+    if (inst.address) eyebrowParts.push(TSEB.util.esc(inst.address));
+    if (inst.zip_code) eyebrowParts.push(TSEB.util.esc(inst.zip_code));
+    const eyebrowHTML = eyebrowParts.length
+      ? '<div class="eyebrow detail-eyebrow">' + eyebrowParts.join(' &middot; ') + '</div>'
+      : '';
+
+    // Status pill row (all statuses, current is active)
+    const allStatuses = ['initial_contact','in_conversation','site_visit','active','on_hold','previous','inactive'];
+    const statusRow = allStatuses.map(function(s) {
+      const isCurrent = s === inst.status;
+      const onClick = isCurrent ? '' : ' onclick="TSEB.outreach.changeStatus(\'' + id + '\', \'' + s + '\')"';
+      return TSEB.util.statusPill(s, { active: isCurrent, attrs: onClick });
+    }).join(' ');
+
+    // Next-action banner — paper-2 background, italic display body
+    let nextActionHTML = '';
+    if (inst.next_step) {
+      const dueText = overdue
+        ? 'Overdue · ' + daysOverdue + ' day' + (daysOverdue === 1 ? '' : 's')
+        : 'Due ' + TSEB.util.fmtDate(inst.next_step_due);
+      nextActionHTML =
+        '<div class="detail-next-action">' +
+        '<div class="eyebrow detail-next-eyebrow' + (overdue ? ' is-overdue' : '') + '">Next action &middot; ' + TSEB.util.esc(dueText) + '</div>' +
+        '<div class="detail-next-body">' + TSEB.util.esc(inst.next_step) + '</div>' +
+        '<button class="btn btn-accent detail-next-cta" onclick="TSEB.outreach.openLogActivity(\'' + id + '\')">Log activity</button>' +
+        '</div>';
+    } else {
+      nextActionHTML =
+        '<div class="detail-next-action">' +
+        '<div class="eyebrow">No next step set</div>' +
+        '<button class="btn btn-accent detail-next-cta" onclick="TSEB.outreach.openLogActivity(\'' + id + '\')">Log activity</button>' +
+        '</div>';
+    }
+
+    // Contacts (line items, dotted divider between)
+    let contactsHTML = '<div class="detail-section">' +
+      '<div class="detail-section-head">' +
+      '<div class="eyebrow">Contacts</div>' +
+      '<button class="detail-section-action" onclick="TSEB.outreach.openAddContact(\'' + id + '\')">+ Add</button>' +
+      '</div>';
+    if (contacts && contacts.length) {
+      contactsHTML += contacts.map(function(c, i) {
+        const cName = ((c.first_name || '') + ' ' + (c.last_name || '')).trim();
+        const titleHTML = c.job_title
+          ? '<span class="smcaps faint">' + TSEB.util.esc(c.job_title) + (c.is_primary ? ' &middot; primary' : '') + '</span>'
+          : (c.is_primary ? '<span class="smcaps faint">primary</span>' : '');
+        const phoneHTML = c.phone
+          ? '<a class="detail-contact-phone" href="tel:' + TSEB.util.esc(c.phone) + '" onclick="event.stopPropagation();">' + TSEB.util.esc(c.phone) + '</a>'
+          : '';
+        const emailHTML = c.email
+          ? '<a class="detail-contact-email" href="mailto:' + TSEB.util.esc(c.email) + '" onclick="event.stopPropagation();">' + TSEB.util.esc(c.email) + '</a>'
+          : '';
+        return '<div class="detail-contact" onclick="TSEB.outreach.openEditContact(\'' + c.id + '\', \'' + id + '\')">' +
+          '<div class="detail-contact-row">' +
+          '<span class="detail-contact-name">' + TSEB.util.esc(cName) + '</span>' +
+          titleHTML +
+          '</div>' +
+          (phoneHTML || emailHTML
+            ? '<div class="detail-contact-meta">' + phoneHTML + (phoneHTML && emailHTML ? '<span class="meta-sep">·</span>' : '') + emailHTML + '</div>'
+            : '') +
+          '</div>';
+      }).join('');
+    } else {
+      contactsHTML += '<div class="detail-empty">No contacts yet.</div>';
+    }
+    contactsHTML += '</div>';
+
+    // Timeline
+    let timelineHTML = '<div class="detail-section">' +
+      '<div class="detail-section-head"><div class="eyebrow">Timeline</div></div>';
+    if (activities && activities.length) {
+      timelineHTML += '<div class="detail-timeline">' + activities.map(function(a) {
+        const tLabel = (a.activity_type || '').replace(/_/g, ' ').replace(/\b\w/g, function(c) { return c.toUpperCase(); });
+        const dateShort = TSEB.util.fmtDateShort(a.activity_date);
+        return '<div class="detail-timeline-row">' +
+          '<div class="detail-timeline-date">' +
+          '<div class="smcaps faint">' + TSEB.util.esc(dateShort) + '</div>' +
+          '<div class="smcaps detail-timeline-type">' + TSEB.util.esc(tLabel) + '</div>' +
+          '</div>' +
+          '<div class="detail-timeline-rule"><span class="dot"></span></div>' +
+          '<div class="detail-timeline-note">' + TSEB.util.esc(a.description || '') +
+          (a.singer ? ' <span class="smcaps faint">&middot; ' + TSEB.util.esc(a.singer.first_name) + '</span>' : '') +
+          '</div>' +
+          '</div>';
+      }).join('') + '</div>';
+    } else {
+      timelineHTML += '<div class="detail-empty">No activity logged yet.</div>';
+    }
+    timelineHTML += '</div>';
+
+    const notesHTML = inst.notes
+      ? '<div class="detail-section">' +
+          '<div class="detail-section-head"><div class="eyebrow">Notes</div></div>' +
+          '<div class="detail-notes">' + TSEB.util.esc(inst.notes) + '</div>' +
+        '</div>'
+      : '';
+
     const html =
-      '<div class="modal-header">' +
-      '<button class="modal-back-btn" onclick="TSEB.closeDetail()" aria-label="Close">&#8592;</button>' +
-      '<div class="modal-title">' + TSEB.util.esc(inst.name) + '</div>' +
+      '<div class="detail-topbar">' +
+      '<button class="topbar-link" onclick="TSEB.closeDetail()" aria-label="Close">&larr; Outreach</button>' +
+      '<button class="topbar-link topbar-link-accent" onclick="TSEB.outreach.openEditForm(\'' + id + '\')">Edit</button>' +
       '</div>' +
-      '<div class="modal-body">' +
-      '<div style="margin-bottom:16px;">' +
-      (typeLabel ? '<div style="font-size:15px; color:var(--muted);">' + TSEB.util.esc(typeLabel) + '</div>' : '') +
-      (inst.address || inst.zip_code ? '<div style="font-size:15px; color:var(--muted);">' + TSEB.util.esc(inst.address || '') + (inst.address && inst.zip_code ? ' · ' : '') + (inst.zip_code ? TSEB.util.esc(inst.zip_code) : '') + '</div>' : '') +
-      '<div style="margin-top:8px;">' + TSEB.util.statusBadge(inst.status) + '</div>' +
+      '<div class="detail-body">' +
+      '<div class="detail-hero">' +
+      eyebrowHTML +
+      '<h1 class="detail-title">' + TSEB.util.esc(inst.name) + '</h1>' +
+      '<div class="detail-status-row">' + statusRow + '</div>' +
       '</div>' +
-
-      nextStepBanner +
-
-      '<div style="display:flex; gap:10px; margin-bottom:20px;">' +
-      '<button class="btn btn-primary" style="flex:1;" onclick="TSEB.outreach.openLogActivity(\'' + id + '\')">Log Activity</button>' +
-      '<button class="btn btn-secondary" onclick="TSEB.outreach.openEditForm(\'' + id + '\')">Edit</button>' +
-      '</div>' +
-
-      (inst.outreacher
-        ? '<div style="margin-bottom:16px;"><span style="font-size:14px; color:var(--muted); margin-right:8px;">Outreacher:</span>' + TSEB.util.singerChip(inst.outreacher.first_name) + '</div>'
-        : '') +
-
+      '<hr class="h-rule">' +
+      nextActionHTML +
       contactsHTML +
-
-      '<div style="margin-bottom:20px;">' +
-      '<h4 style="font-size:14px; font-weight:700; text-transform:uppercase; letter-spacing:.06em; color:var(--muted); margin-bottom:10px;">Change Status</h4>' +
-      '<div style="display:flex; flex-wrap:wrap; gap:8px;">' + statusButtons + '</div>' +
-      '</div>' +
-
-      '<div style="margin-bottom:20px;">' +
-      '<h4 style="font-size:14px; font-weight:700; text-transform:uppercase; letter-spacing:.06em; color:var(--muted); margin-bottom:10px;">Timeline</h4>' +
+      '<hr class="h-rule">' +
       timelineHTML +
-      '</div>' +
-
-      (inst.notes
-        ? '<div style="margin-bottom:20px;"><h4 style="font-size:14px; font-weight:700; text-transform:uppercase; letter-spacing:.06em; color:var(--muted); margin-bottom:10px;">Notes</h4><p style="font-size:15px;">' + TSEB.util.esc(inst.notes) + '</p></div>'
-        : '') +
-
+      notesHTML +
       '</div>';
 
     TSEB.showDetail(html);
@@ -679,73 +662,78 @@ TSEB.outreach = {
     const inst = this._data ? this._data.find(function(i) { return i.id === institutionId; }) : null;
     const instName = inst ? inst.name : 'Facility';
 
+    // Activity type buttons (status-pill style)
+    const activityTypes = [
+      { value: 'phone_call', label: 'Call' },
+      { value: 'email_sent', label: 'Email' },
+      { value: 'in_person', label: 'Visit' },
+      { value: 'site_visit', label: 'Site Visit' },
+      { value: 'voicemail', label: 'Voicemail' },
+      { value: 'note', label: 'Note' }
+    ];
+    const typeButtons = activityTypes.map(function(t) {
+      return '<button type="button" class="status-pill activity-type-btn" data-value="' + t.value +
+        '" onclick="TSEB.outreach._pickActivityType(this)">' +
+        '<span class="dot"></span>' + t.label + '</button>';
+    }).join('');
+
     const html =
-      '<div class="modal-header">' +
-      '<button class="modal-back-btn" onclick="TSEB.closeForm(); TSEB.outreach.showDetail(\'' + institutionId + '\')" aria-label="Back">&#8592;</button>' +
-      '<div class="modal-title">Log Activity</div>' +
+      '<div class="form-topbar">' +
+      '<button type="button" class="topbar-link" onclick="TSEB.closeForm(); TSEB.outreach.showDetail(\'' + institutionId + '\')">Cancel</button>' +
+      '<button type="submit" form="log-activity-form" class="topbar-link topbar-link-accent">Save</button>' +
       '</div>' +
-      '<div class="modal-body">' +
-      '<div style="font-size:15px; color:var(--muted); margin-bottom:20px;">For: <strong style="color:var(--text);">' + TSEB.util.esc(instName) + '</strong></div>' +
+      '<div class="form-body">' +
       '<form id="log-activity-form" onsubmit="event.preventDefault(); TSEB.outreach.submitLogActivity(this);">' +
       '<input type="hidden" name="institution_id" value="' + institutionId + '">' +
+      '<input type="hidden" name="activity_type" id="log-activity-type" required value="phone_call">' +
 
-      '<div class="form-group">' +
-      '<label class="form-label" for="log-singer">Who did this?</label>' +
-      '<select id="log-singer" name="singer_id" class="form-select">' +
-      '<option value="">Select singer...</option>' + singerOptions +
+      '<div class="eyebrow">Logging activity at</div>' +
+      '<h1 class="form-title">' + TSEB.util.esc(instName) + '</h1>' +
+
+      '<label class="eyebrow form-eyebrow-label">Type</label>' +
+      '<div class="form-pill-row">' + typeButtons + '</div>' +
+
+      '<label class="eyebrow form-eyebrow-label">Who did this?</label>' +
+      '<select name="singer_id" class="form-select form-select-bare">' +
+      '<option value="">Choose singer&hellip;</option>' + singerOptions +
       '</select>' +
+
+      '<label class="eyebrow form-eyebrow-label">Contact at the facility</label>' +
+      '<input name="contact_person" type="text" class="form-input" placeholder="Name (optional)">' +
+
+      '<label class="eyebrow form-eyebrow-label">What happened?</label>' +
+      '<textarea name="description" class="form-input form-textarea" rows="3" required placeholder="A few words about the interaction&hellip;"></textarea>' +
+
+      '<label class="eyebrow form-eyebrow-label">Date</label>' +
+      '<input name="activity_date" type="date" class="form-input form-input-display" value="' + today + '" required>' +
+
+      '<div class="form-next-step-block">' +
+      '<div class="eyebrow form-next-step-eyebrow">Next step (optional)</div>' +
+      '<input name="next_step" type="text" class="form-input form-input-italic" placeholder="What happens next?">' +
+      '<label class="smcaps faint form-next-step-due-label">Due</label>' +
+      '<input name="next_step_due" type="date" class="form-input form-input-italic">' +
       '</div>' +
 
-      '<div class="form-group">' +
-      '<label class="form-label" for="log-type">Activity Type *</label>' +
-      '<select id="log-type" name="activity_type" class="form-select" required>' +
-      '<option value="">Select type...</option>' +
-      '<option value="phone_call">Phone Call</option>' +
-      '<option value="voicemail">Voicemail</option>' +
-      '<option value="email_sent">Email Sent</option>' +
-      '<option value="email_received">Email Received</option>' +
-      '<option value="in_person">In Person</option>' +
-      '<option value="site_visit">Site Visit</option>' +
-      '<option value="first_sing">First Sing</option>' +
-      '<option value="status_change">Status Change</option>' +
-      '<option value="note">Note</option>' +
-      '</select>' +
-      '</div>' +
-
-      '<div class="form-group">' +
-      '<label class="form-label" for="log-date">Date *</label>' +
-      '<input id="log-date" name="activity_date" type="date" class="form-input" value="' + today + '" required>' +
-      '</div>' +
-
-      '<div class="form-group">' +
-      '<label class="form-label" for="log-contact">Who did you speak with?</label>' +
-      '<input id="log-contact" name="contact_person" type="text" class="form-input" placeholder="Name at the facility">' +
-      '</div>' +
-
-      '<div class="form-group">' +
-      '<label class="form-label" for="log-desc">What happened? *</label>' +
-      '<textarea id="log-desc" name="description" class="form-input" rows="4" placeholder="Describe the interaction..." required></textarea>' +
-      '</div>' +
-
-      '<details style="margin-bottom:16px;">' +
-      '<summary style="font-size:16px; font-weight:600; cursor:pointer; padding:8px 0; color:var(--primary);">Update next step (optional)</summary>' +
-      '<div style="margin-top:12px;">' +
-      '<div class="form-group">' +
-      '<label class="form-label" for="log-next-step">Next Step</label>' +
-      '<input id="log-next-step" name="next_step" type="text" class="form-input" placeholder="What happens next?">' +
-      '</div>' +
-      '<div class="form-group">' +
-      '<label class="form-label" for="log-next-due">Due Date</label>' +
-      '<input id="log-next-due" name="next_step_due" type="date" class="form-input">' +
-      '</div>' +
-      '</div></details>' +
-
-      '<button type="submit" class="btn btn-primary" style="width:100%;">Save Activity</button>' +
+      '<button type="submit" class="btn btn-accent form-submit">Save activity</button>' +
       '</form>' +
       '</div>';
 
     TSEB.closeDetail();
     TSEB.showForm(html);
+
+    // Mark first activity-type pill as active by default
+    setTimeout(function() {
+      const first = document.querySelector('.activity-type-btn[data-value="phone_call"]');
+      if (first) first.classList.add('is-active');
+    }, 50);
+  },
+
+  _pickActivityType: function(btn) {
+    const all = document.querySelectorAll('.activity-type-btn');
+    all.forEach(function(b) { b.classList.remove('is-active'); });
+    btn.classList.add('is-active');
+    const hidden = document.getElementById('log-activity-type');
+    if (hidden) hidden.value = btn.dataset.value;
   },
 
   async submitLogActivity(form) {


### PR DESCRIPTION
## Summary

Second pass of the Plainchant redesign — rebuilds the Outreach screen rendering to match the design handoff prototype. Stacks on top of [PR #4](https://github.com/jhwright/TSEB/pull/4) (Plainchant foundation).

Cards, status filter pills, the overdue callout, the facility detail overlay, and the log-activity form all move from the legacy boxy layout to the manuscript pattern: italic display titles, ink-underline fields, status-pill type chooser, paper-2 next-action banner with full-width ochre CTA, dotted-rule timeline.

- New helpers: `TSEB.util.statusPill` / `statusLabel`. `statusBadge` becomes a thin alias so legacy callers still work
- **Outreach list**
  - Callout: italic display numeral + "tend →" link, paper-2 warning banner replacing the old "Follow-up needed:" line
  - Filter toggle row gains a right-aligned count
  - Status pills: ink-fill active state, small count chip on the right
  - Cards: italic display name, smcaps subtitle, accent left-rule next-step block (warning when overdue), "↳ Contact" smcaps line
- **Facility detail overlay**
  - Smcaps top bar (← Outreach / Edit)
  - Italic 30px title + tap-to-change status pills row
  - Paper-2 "Next action" banner with italic display body and full-width ochre Log activity CTA
  - Contacts as line items with dotted dividers, mono phone/email
  - Timeline gets the manuscript date column + ochre dot + 1px rule
- **Log-activity form**
  - Cancel / Save smcaps top bar
  - "Logging activity at" eyebrow + italic display facility title
  - Status-pill type chooser (Call / Email / Visit / Site Visit / Voicemail / Note)
  - Ink-underline fields, italic textarea
  - Paper-2 "Next step (optional)" block

Add/Edit Facility and Add/Edit Contact still use the existing modal-header pattern; restyling those is a follow-up polish PR.

## Test plan

- [ ] Outreach list shows italic callout, smcaps All/Mine tabs, status pill row with counts
- [ ] Tap a status pill — list filters, count updates, pill goes ink-fill
- [ ] Cards: italic title, smcaps subtitle (type · address · zip), accent or warning left-rule on next step
- [ ] Tap a card — detail opens with smcaps top bar, italic title, status pills, paper-2 next-action banner, contacts, timeline
- [ ] Tap a status pill in detail — status changes, detail re-renders, activity logged
- [ ] Tap Log activity — form opens with type pills, italic textarea, paper-2 next-step block
- [ ] Submit log activity — saves, closes form, returns to detail with new timeline entry
- [ ] Add/Edit Facility and Add/Edit Contact forms still functional (using the existing modal-header)

🤖 Generated with [Claude Code](https://claude.com/claude-code)