### PR TITLE
Redesign Schedule: Calendar / Agenda / Map view picker

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -888,7 +888,7 @@ main[role="main"] {
   position: fixed;
   inset: 0;
   background: rgba(20, 20, 20, .35);
-  z-index: 200;
+  z-index: 1000;
   display: flex;
   align-items: stretch;
   justify-content: center;
@@ -1267,6 +1267,431 @@ main[role="main"] {
 .form-submit {
   margin-top: 22px;
   width: 100%;
+}
+
+/* =============================================================================
+   Schedule — view picker, calendar, agenda, map
+   ============================================================================= */
+
+.sched-picker {
+  padding: 14px 22px 12px;
+  border-bottom: 1px solid var(--rule-soft);
+}
+
+.sched-picker-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.sched-picker-btn {
+  padding: 10px 6px;
+  font-size: 10px;
+  font-family: var(--font-ui);
+  letter-spacing: .18em;
+  text-transform: uppercase;
+  background: var(--paper);
+  color: var(--ink);
+  border: 1px solid var(--rule);
+  cursor: pointer;
+  border-radius: var(--radius);
+  transition: background 200ms ease-out, color 200ms ease-out, border-color 200ms ease-out;
+}
+
+.sched-picker-btn:hover {
+  background: var(--paper-2);
+}
+
+.sched-picker-btn.is-active {
+  background: var(--accent);
+  color: var(--paper);
+  border-color: var(--accent);
+}
+
+.sched-picker-hint {
+  margin-top: 8px;
+  font-size: 9px;
+  font-family: var(--font-ui);
+  letter-spacing: .18em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+
+/* Calendar */
+.sched-cal-head {
+  padding: 16px 22px 8px;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.sched-cal-nav {
+  font-family: var(--font-ui);
+  font-size: 10px;
+  letter-spacing: .18em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px 6px;
+}
+
+.sched-cal-nav:hover {
+  color: var(--accent-deep);
+}
+
+.sched-cal-month {
+  text-align: center;
+}
+
+.sched-cal-month-name {
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: 24px;
+  margin: 2px 0 0;
+  font-weight: 500;
+}
+
+.sched-cal-grid {
+  padding: 8px 16px 0;
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+}
+
+.sched-cal-dow {
+  text-align: center;
+  padding: 8px 0;
+  font-size: 9px;
+  font-family: var(--font-ui);
+  letter-spacing: .18em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+
+.sched-cal-cell {
+  aspect-ratio: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-display);
+  font-size: 17px;
+  position: relative;
+  cursor: default;
+}
+
+.sched-cal-cell.has-gig {
+  cursor: pointer;
+}
+
+.sched-cal-cell.is-today {
+  border: 1px solid var(--accent);
+}
+
+.sched-cal-cell.is-other {
+  color: var(--ink-faint);
+  opacity: .4;
+}
+
+.sched-cal-cell.is-today .sched-cal-num {
+  font-style: italic;
+  color: var(--accent-deep);
+}
+
+.sched-cal-num {
+  line-height: 1;
+}
+
+.sched-cal-dot {
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--accent);
+  margin-top: 3px;
+}
+
+.sched-upcoming {
+  padding: 0 22px 22px;
+}
+
+.sched-upcoming-eyebrow {
+  margin-bottom: 10px;
+}
+
+.sched-upcoming-row {
+  display: flex;
+  gap: 14px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--rule-soft);
+  cursor: pointer;
+}
+
+.sched-upcoming-row:last-child {
+  border-bottom: none;
+}
+
+.sched-upcoming-date {
+  width: 42px;
+  flex-shrink: 0;
+  text-align: center;
+}
+
+.sched-upcoming-dow {
+  font-size: 9px;
+  font-family: var(--font-ui);
+  letter-spacing: .18em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+
+.sched-upcoming-day {
+  font-family: var(--font-display);
+  font-size: 28px;
+  line-height: 1;
+  font-style: italic;
+  color: var(--accent-deep);
+  font-weight: 500;
+}
+
+.sched-upcoming-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.sched-upcoming-venue {
+  font-family: var(--font-display);
+  font-size: 17px;
+  font-weight: 500;
+  line-height: 1.2;
+}
+
+.sched-upcoming-meta {
+  margin-top: 2px;
+  font-family: var(--font-ui);
+  font-size: 10px;
+  letter-spacing: .18em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+}
+
+.sched-upcoming-singers {
+  margin-top: 6px;
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+.sched-singer-chip {
+  font-family: var(--font-ui);
+  font-size: 10px;
+  padding: 2px 8px;
+  border: 1px solid var(--rule);
+  border-radius: 999px;
+  color: var(--ink-soft);
+  background: var(--paper);
+}
+
+/* Agenda + Map shared timeline */
+.sched-agenda-head,
+.sched-map-head {
+  padding: 16px 22px 16px;
+}
+
+.sched-agenda-eyebrow,
+.sched-map-eyebrow {
+  margin-bottom: 4px;
+}
+
+.sched-agenda-title,
+.sched-map-title {
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: 26px;
+  font-weight: 500;
+  margin: 4px 0 0;
+  line-height: 1.2;
+}
+
+.sched-tl-list {
+  padding: 0 22px 22px;
+}
+
+.sched-tl-row {
+  display: flex;
+  gap: 18px;
+  padding-bottom: 22px;
+  cursor: pointer;
+}
+
+.sched-tl-row:last-child {
+  padding-bottom: 0;
+}
+
+.sched-tl-date {
+  width: 70px;
+  flex-shrink: 0;
+  padding-top: 4px;
+}
+
+.sched-tl-month {
+  font-size: 9px;
+  font-family: var(--font-ui);
+  letter-spacing: .18em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+
+.sched-tl-day {
+  font-family: var(--font-display);
+  font-size: 42px;
+  line-height: .9;
+  font-style: italic;
+  color: var(--accent-deep);
+  font-weight: 500;
+}
+
+.sched-tl-dow {
+  font-size: 9px;
+  font-family: var(--font-ui);
+  letter-spacing: .18em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+  margin-top: 2px;
+}
+
+.sched-tl-rule {
+  width: 1px;
+  background: var(--rule);
+  position: relative;
+  margin-top: 6px;
+  margin-bottom: -22px;
+  flex-shrink: 0;
+}
+
+.sched-tl-row:last-child .sched-tl-rule {
+  margin-bottom: 0;
+}
+
+.sched-tl-rule::before {
+  content: "";
+  position: absolute;
+  left: -4px;
+  top: 4px;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--paper);
+  border: 1.5px solid var(--accent);
+}
+
+.sched-tl-rule.is-numbered::before {
+  left: -10px;
+  top: 0;
+  width: 22px;
+  height: 22px;
+  background: var(--paper);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: 13px;
+  color: var(--accent-deep);
+  font-weight: 500;
+  content: attr(data-num);
+}
+
+.sched-tl-body {
+  flex: 1;
+  padding-top: 4px;
+  min-width: 0;
+}
+
+.sched-tl-venue {
+  font-family: var(--font-display);
+  font-size: 19px;
+  font-weight: 500;
+  line-height: 1.2;
+}
+
+.sched-tl-meta {
+  margin-top: 4px;
+  font-family: var(--font-ui);
+  font-size: 10px;
+  letter-spacing: .18em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+}
+
+.sched-tl-singers {
+  margin-top: 8px;
+  font-family: var(--font-body);
+  font-size: 14px;
+  font-style: italic;
+  color: var(--ink-soft);
+  line-height: 1.4;
+}
+
+.sched-tl-notes {
+  margin-top: 8px;
+  font-size: 13px;
+  color: var(--ink-faint);
+  padding-left: 10px;
+  border-left: 1px solid var(--rule);
+  font-style: italic;
+}
+
+/* Leaflet map */
+.sched-map-canvas {
+  margin: 0 22px 22px;
+  border: 1px solid var(--rule);
+  height: 240px;
+  position: relative;
+  background: var(--paper-2);
+  overflow: hidden;
+  border-radius: var(--radius);
+}
+
+.tseb-pin {
+  background: none;
+  border: none;
+}
+
+.tseb-pin .tseb-pin-inner {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px 4px 8px;
+  background: var(--paper);
+  border: 1px solid var(--accent);
+  border-radius: 999px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, .12);
+  white-space: nowrap;
+  font-family: var(--font-ui);
+}
+
+.tseb-pin .n {
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: 14px;
+  color: var(--accent-deep);
+  font-weight: 500;
+  line-height: 1;
+}
+
+.tseb-pin .d {
+  font-size: 9px;
+  letter-spacing: .18em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+  line-height: 1;
+}
+
+.leaflet-container {
+  background: var(--paper-2);
+  font-family: var(--font-ui);
 }
 
 /* =============================================================================

--- a/css/style.css
+++ b/css/style.css
@@ -420,6 +420,12 @@ hr.h-rule {
   border-color: var(--ink);
 }
 
+.status-pill-count {
+  margin-left: 6px;
+  font-size: 9px;
+  opacity: .7;
+}
+
 /* =============================================================================
    Cards (no rounded corners, divider style)
    ============================================================================= */
@@ -451,6 +457,66 @@ hr.h-rule {
   text-transform: uppercase;
   color: var(--ink-faint);
   margin-top: 4px;
+}
+
+.outreach-card {
+  padding: 18px 22px;
+}
+
+.card-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 10px;
+}
+
+.card-subtitle {
+  font-family: var(--font-ui);
+  font-size: 10px;
+  letter-spacing: .18em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin-top: 4px;
+}
+
+.card-next-step {
+  margin-top: 12px;
+  padding-left: 12px;
+  border-left: 2px solid var(--accent);
+}
+
+.card-next-step-overdue {
+  border-left-color: var(--warning);
+}
+
+.card-next-step-eyebrow {
+  font-family: var(--font-ui);
+  font-size: 10px;
+  letter-spacing: .22em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin-bottom: 2px;
+}
+
+.card-next-step-overdue .card-next-step-eyebrow {
+  color: var(--warning);
+}
+
+.card-next-step-body {
+  font-family: var(--font-body);
+  font-size: 15px;
+  font-style: italic;
+  line-height: 1.35;
+  color: var(--ink);
+}
+
+.card-contact {
+  margin-top: 12px;
+  font-family: var(--font-ui);
+  font-size: 10px;
+  letter-spacing: .18em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
 }
 
 /* =============================================================================
@@ -675,10 +741,42 @@ main[role="main"] {
   border-top: 1px solid var(--warning);
   border-bottom: 1px solid var(--warning);
   background: color-mix(in oklab, var(--warning-soft) 50%, var(--paper));
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  color: var(--ink);
+}
+
+.callout-numeral {
   font-family: var(--font-display);
   font-style: italic;
-  font-size: 15px;
-  color: var(--ink);
+  font-size: 32px;
+  color: var(--warning);
+  line-height: .8;
+  flex-shrink: 0;
+}
+
+.callout-body {
+  flex: 1;
+}
+
+.callout-headline {
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: 17px;
+  line-height: 1.2;
+}
+
+.callout-sub {
+  margin-top: 2px;
+}
+
+.callout-action {
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: 14px;
+  color: var(--warning);
+  white-space: nowrap;
 }
 
 /* =============================================================================
@@ -748,6 +846,7 @@ main[role="main"] {
 
 .filter-toggle {
   display: flex;
+  align-items: center;
   padding: 16px 22px 10px;
   border-bottom: 1px solid var(--rule-soft);
 }
@@ -758,7 +857,7 @@ main[role="main"] {
   letter-spacing: .18em;
   text-transform: uppercase;
   font-weight: 500;
-  padding: 6px 14px 6px 0;
+  padding: 6px 0;
   margin-right: 18px;
   background: transparent;
   border: none;
@@ -770,6 +869,15 @@ main[role="main"] {
 .filter-toggle-btn.active {
   color: var(--ink);
   border-bottom-color: var(--accent);
+}
+
+.filter-toggle-count {
+  margin-left: auto;
+  font-family: var(--font-ui);
+  font-size: 10px;
+  letter-spacing: .18em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
 }
 
 /* =============================================================================
@@ -845,6 +953,320 @@ main[role="main"] {
 
 .modal-body {
   padding: 22px;
+}
+
+/* =============================================================================
+   Detail screen (Outreach facility, Schedule gig)
+   ============================================================================= */
+
+.detail-topbar {
+  padding: 14px 22px;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  border-bottom: 1px solid var(--rule);
+  background: var(--paper);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.topbar-link {
+  font-family: var(--font-ui);
+  font-size: 10px;
+  letter-spacing: .18em;
+  text-transform: uppercase;
+  font-weight: 500;
+  background: none;
+  border: none;
+  color: var(--ink-faint);
+  cursor: pointer;
+  padding: 0;
+}
+
+.topbar-link-accent {
+  color: var(--accent-deep);
+}
+
+.detail-body {
+  padding-bottom: 80px;
+}
+
+.detail-hero {
+  padding: 18px 22px 18px;
+}
+
+.detail-eyebrow {
+  margin-bottom: 6px;
+}
+
+.detail-title {
+  font-family: var(--font-display);
+  font-size: 30px;
+  font-weight: 500;
+  font-style: italic;
+  margin: 0;
+  line-height: 1.05;
+  color: var(--ink);
+}
+
+.detail-status-row {
+  margin-top: 14px;
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.detail-next-action {
+  padding: 16px 22px 18px;
+  background: var(--paper-2);
+  border-bottom: 1px solid var(--rule);
+}
+
+.detail-next-eyebrow {
+  margin-bottom: 4px;
+}
+
+.detail-next-eyebrow.is-overdue {
+  color: var(--warning);
+}
+
+.detail-next-body {
+  font-family: var(--font-display);
+  font-size: 19px;
+  font-style: italic;
+  line-height: 1.3;
+  color: var(--ink);
+}
+
+.detail-next-cta {
+  margin-top: 12px;
+  width: 100%;
+}
+
+.detail-section {
+  padding: 18px 22px;
+}
+
+.detail-section-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 10px;
+}
+
+.detail-section-action {
+  font-family: var(--font-ui);
+  font-size: 10px;
+  letter-spacing: .18em;
+  text-transform: uppercase;
+  font-weight: 500;
+  background: none;
+  border: none;
+  color: var(--accent-deep);
+  cursor: pointer;
+  padding: 0;
+}
+
+.detail-empty {
+  font-family: var(--font-body);
+  font-style: italic;
+  color: var(--ink-faint);
+  font-size: 14px;
+  padding: 6px 0;
+}
+
+.detail-contact {
+  padding: 10px 0;
+  border-bottom: 1px dotted var(--rule-soft);
+  cursor: pointer;
+}
+
+.detail-contact:last-child {
+  border-bottom: none;
+}
+
+.detail-contact-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.detail-contact-name {
+  font-family: var(--font-display);
+  font-size: 17px;
+  color: var(--ink);
+}
+
+.detail-contact-meta {
+  margin-top: 4px;
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  flex-wrap: wrap;
+}
+
+.detail-contact-phone {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--accent-deep);
+}
+
+.detail-contact-email {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--accent-deep);
+  word-break: break-all;
+}
+
+.detail-contact-meta .meta-sep {
+  color: var(--ink-faint);
+}
+
+.detail-timeline-row {
+  display: flex;
+  gap: 14px;
+  margin-bottom: 16px;
+}
+
+.detail-timeline-date {
+  width: 56px;
+  flex-shrink: 0;
+  text-align: right;
+}
+
+.detail-timeline-type {
+  color: var(--accent);
+  margin-top: 2px;
+  font-size: 9px;
+}
+
+.detail-timeline-rule {
+  width: 1px;
+  background: var(--rule);
+  position: relative;
+  flex-shrink: 0;
+}
+
+.detail-timeline-rule .dot {
+  position: absolute;
+  left: -3px;
+  top: 4px;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--paper);
+  border: 1px solid var(--accent);
+}
+
+.detail-timeline-note {
+  flex: 1;
+  font-family: var(--font-body);
+  font-size: 14.5px;
+  line-height: 1.4;
+  color: var(--ink);
+}
+
+.detail-notes {
+  font-family: var(--font-body);
+  font-style: italic;
+  font-size: 15px;
+  line-height: 1.5;
+  color: var(--ink-soft);
+}
+
+/* =============================================================================
+   Form layouts (manuscript style — borderless, italic, smcaps labels)
+   ============================================================================= */
+
+.form-topbar {
+  padding: 14px 22px;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  border-bottom: 1px solid var(--rule);
+  background: var(--paper);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.form-body {
+  padding: 18px 22px 80px;
+}
+
+.form-title {
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: 24px;
+  font-weight: 500;
+  margin: 4px 0 22px;
+  line-height: 1.1;
+  color: var(--ink);
+}
+
+.form-eyebrow-label {
+  display: block;
+  margin-bottom: 8px;
+  margin-top: 22px;
+}
+
+.form-eyebrow-label:first-of-type {
+  margin-top: 0;
+}
+
+.form-pill-row {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-bottom: 4px;
+}
+
+.activity-type-btn {
+  background: transparent;
+  cursor: pointer;
+  font-family: var(--font-ui);
+}
+
+.form-input-display {
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: 18px;
+}
+
+.form-input-italic {
+  font-style: italic;
+  font-size: 15px;
+  color: var(--ink-soft);
+}
+
+.form-select-bare {
+  background-position: right 4px center;
+}
+
+.form-next-step-block {
+  margin-top: 26px;
+  padding: 16px;
+  border: 1px solid var(--rule);
+  background: var(--paper-2);
+}
+
+.form-next-step-eyebrow {
+  color: var(--accent-deep);
+  margin-bottom: 8px;
+}
+
+.form-next-step-due-label {
+  display: block;
+  margin-top: 12px;
+  margin-bottom: 4px;
+  font-size: 9px;
+}
+
+.form-submit {
+  margin-top: 22px;
+  width: 100%;
 }
 
 /* =============================================================================

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Spectral:ital,wght@0,300;0,400;0,500;0,600;1,400&family=Cardo:ital,wght@0,400;0,700;1,400&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body class="dir-plainchant">
@@ -142,6 +143,7 @@
 
   <!-- Scripts -->
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2" onerror="document.getElementById('cdn-error').style.display='block'"></script>
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
   <script defer src="js/config.js"></script>
   <script defer src="js/app.js"></script>
   <script defer src="js/auth.js"></script>

--- a/js/app.js
+++ b/js/app.js
@@ -137,18 +137,37 @@ TSEB.util.isSoon = function(d) {
   return dt >= now && dt <= week;
 };
 
+TSEB.util.STATUS_LABELS = {
+  initial_contact: 'Initial',
+  in_conversation: 'Talking',
+  site_visit: 'Site Visit',
+  active: 'Active',
+  on_hold: 'Hold',
+  previous: 'Previous',
+  inactive: 'Inactive'
+};
+
+TSEB.util.statusLabel = function(status) {
+  return TSEB.util.STATUS_LABELS[status] ||
+    (status || '').replace(/_/g, ' ').replace(/\b\w/g, function(c) { return c.toUpperCase(); });
+};
+
+// Render a manuscript status pill. opts.compact=true drops the border for inline use.
+// opts.active=true inverts the pill (ink fill, paper text). opts.attrs adds raw HTML attrs.
+TSEB.util.statusPill = function(status, opts) {
+  opts = opts || {};
+  const label = TSEB.util.statusLabel(status);
+  const cls = ['status-pill'];
+  if (opts.active) cls.push('is-active');
+  const style = opts.compact ? ' style="border-color:transparent; padding:2px 0; font-size:9px;"' : '';
+  const attrs = opts.attrs ? ' ' + opts.attrs : '';
+  return '<span class="' + cls.join(' ') + '" data-status="' + status + '"' + style + attrs +
+    '><span class="dot"></span>' + TSEB.util.esc(label) + '</span>';
+};
+
+// Legacy alias — prefer statusPill in new code.
 TSEB.util.statusBadge = function(status) {
-  const map = {
-    active: 'badge-active',
-    initial_contact: 'badge-initial',
-    in_conversation: 'badge-conversation',
-    site_visit: 'badge-conversation',
-    on_hold: 'badge-muted',
-    previous: 'badge-muted',
-    inactive: 'badge-overdue'
-  };
-  const label = (status || '').replace(/_/g, ' ').replace(/\b\w/g, function(c) { return c.toUpperCase(); });
-  return '<span class="badge ' + (map[status] || 'badge-muted') + '">' + label + '</span>';
+  return TSEB.util.statusPill(status);
 };
 
 TSEB.util.fmtTime = function(t) {

--- a/js/outreach.js
+++ b/js/outreach.js
@@ -28,9 +28,11 @@ TSEB.outreach = {
   _renderFilter() {
     const el = document.getElementById('outreach-filter');
     if (!el) return;
+    const data = this._filtered();
     el.innerHTML =
-      '<button class="filter-toggle-btn' + (this._filter === 'all' ? ' active' : '') + '" onclick="TSEB.outreach.setFilter(\'all\')">All</button>' +
-      '<button class="filter-toggle-btn' + (this._filter === 'mine' ? ' active' : '') + '" onclick="TSEB.outreach.setFilter(\'mine\')">Mine</button>';
+      '<button class="filter-toggle-btn' + (this._filter === 'all' ? ' active' : '') + '" onclick="TSEB.outreach.setFilter(\'all\')">All facilities</button>' +
+      '<button class="filter-toggle-btn' + (this._filter === 'mine' ? ' active' : '') + '" onclick="TSEB.outreach.setFilter(\'mine\')">Mine</button>' +
+      '<span class="filter-toggle-count">' + data.length + '</span>';
   },
 
   setFilter(val) {
@@ -60,6 +62,7 @@ TSEB.outreach = {
     } else {
       this._statusFilter = (this._statusFilter === status) ? null : status;
     }
+    this._renderFilter();
     this._renderPills();
     this._renderCards();
     this._renderCallout();
@@ -88,14 +91,15 @@ TSEB.outreach = {
     }
 
     el.style.display = '';
-    const parts = [];
-    if (overdue.length > 0) {
-      parts.push('<strong style="color:var(--error);">' + overdue.length + ' overdue</strong>');
-    }
-    if (soon.length > 0) {
-      parts.push('<strong style="color:var(--warning);">' + soon.length + ' due this week</strong>');
-    }
-    el.innerHTML = 'Follow-up needed: ' + parts.join(' · ');
+    const overdueCount = overdue.length;
+    const soonCount = soon.length;
+    el.innerHTML =
+      '<span class="callout-numeral">' + overdueCount + '</span>' +
+      '<div class="callout-body">' +
+        '<div class="callout-headline">overdue follow-up' + (overdueCount === 1 ? '' : 's') + '</div>' +
+        (soonCount > 0 ? '<div class="eyebrow callout-sub">+' + soonCount + ' due this week</div>' : '') +
+      '</div>' +
+      '<span class="callout-action">tend &rarr;</span>';
   },
 
   _renderPills() {
@@ -103,50 +107,23 @@ TSEB.outreach = {
     if (!el) return;
     const data = this._data || [];
 
-    const statusGroups = {
-      initial_contact: 0,
-      in_conversation: 0,
-      site_visit: 0,
-      active: 0,
-      on_hold: 0,
-      previous: 0,
-      inactive: 0
-    };
+    const order = ['initial_contact', 'in_conversation', 'site_visit', 'active', 'on_hold', 'previous', 'inactive'];
+    const counts = {};
+    order.forEach(function(k) { counts[k] = 0; });
     data.forEach(function(i) {
-      if (i.status in statusGroups) statusGroups[i.status]++;
+      if (i.status in counts) counts[i.status]++;
     });
 
-    const labels = {
-      initial_contact: 'Initial',
-      in_conversation: 'Talking',
-      site_visit: 'Site Visit',
-      active: 'Active',
-      on_hold: 'Hold',
-      previous: 'Previous',
-      inactive: 'Inactive'
-    };
-    const badgeClass = {
-      initial_contact: 'badge-initial',
-      in_conversation: 'badge-conversation',
-      site_visit: 'badge-conversation',
-      active: 'badge-active',
-      on_hold: 'badge-muted',
-      previous: 'badge-muted',
-      inactive: 'badge-overdue'
-    };
-
     var self = this;
-    el.innerHTML = Object.keys(statusGroups).map(function(key) {
-      var count = statusGroups[key];
-      if (count === 0) return '';
-      var isActive = self._statusFilter === key;
-      var activeStyle = isActive ? 'outline:3px solid var(--primary); outline-offset:1px; font-weight:700;' : '';
-      return '<span class="badge ' + (badgeClass[key] || 'badge-muted') + '" ' +
-        'style="cursor:pointer; ' + activeStyle + '" ' +
+    el.innerHTML = order.map(function(key) {
+      if (counts[key] === 0) return '';
+      const isActive = self._statusFilter === key;
+      const label = TSEB.util.statusLabel(key);
+      return '<span class="status-pill' + (isActive ? ' is-active' : '') + '" data-status="' + key + '" ' +
         'onclick="TSEB.outreach.setStatusFilter(\'' + key + '\')">' +
-        labels[key] + ' · ' + count + '</span>';
-    }).join('') +
-    (self._statusFilter ? ' <span style="font-size:13px; color:var(--primary); cursor:pointer; text-decoration:underline;" onclick="TSEB.outreach.setStatusFilter(null)">Clear filter</span>' : '');
+        '<span class="dot"></span>' + label +
+        '<span class="status-pill-count">' + counts[key] + '</span></span>';
+    }).join('');
   },
 
   _renderCards() {
@@ -183,42 +160,47 @@ TSEB.outreach = {
 
   _cardHTML(i) {
     const overdue = TSEB.util.isOverdue(i.next_step_due);
-    const soon = TSEB.util.isSoon(i.next_step_due);
-    const cardClass = 'card' + (overdue ? ' card-overdue' : '');
 
+    // Subtitle: "{type} · {city or address head} · {zip}"
+    const typeLabel = i.institution_type
+      ? i.institution_type.replace(/_/g, ' ').replace(/\b\w/g, function(c) { return c.toUpperCase(); })
+      : '';
+    const subtitleParts = [];
+    if (typeLabel) subtitleParts.push(TSEB.util.esc(typeLabel));
+    if (i.address) subtitleParts.push(TSEB.util.esc(i.address));
+    if (i.zip_code) subtitleParts.push(TSEB.util.esc(i.zip_code));
+    const subtitleHTML = subtitleParts.length
+      ? '<div class="card-subtitle">' + subtitleParts.join(' &middot; ') + '</div>'
+      : '';
+
+    // Next step block (italic body + accent left rule, warning if overdue)
     let nextStepHTML = '';
     if (i.next_step) {
-      const dateText = overdue ? 'Overdue' : (soon ? 'Due ' + TSEB.util.fmtDateShort(i.next_step_due) : TSEB.util.fmtDateShort(i.next_step_due));
-      const dateStyle = overdue ? 'color:var(--error); font-weight:700;' : (soon ? 'color:var(--warning); font-weight:600;' : 'color:var(--muted);');
-      nextStepHTML = '<div class="card-next-step">' +
-        '<span style="' + dateStyle + ' font-size:13px;">' + TSEB.util.esc(dateText) + '</span>' +
-        ' — ' + TSEB.util.esc(i.next_step) +
+      const dateText = overdue ? 'Overdue' : ('Due ' + TSEB.util.fmtDateShort(i.next_step_due));
+      nextStepHTML = '<div class="card-next-step' + (overdue ? ' card-next-step-overdue' : '') + '">' +
+        '<div class="card-next-step-eyebrow">Next &middot; ' + TSEB.util.esc(dateText) + '</div>' +
+        '<div class="card-next-step-body">' + TSEB.util.esc(i.next_step) + '</div>' +
         '</div>';
     }
 
-    const outreacherHTML = i.outreacher
-      ? '<span style="margin-right:8px;">' + TSEB.util.singerChip(i.outreacher.first_name) + '</span>'
-      : '';
-
-    // Primary contact
+    // Primary contact (smcaps "↳ Name")
     var primary = (i.contacts || []).find(function(c) { return c.is_primary; }) || (i.contacts || [])[0];
     var contactLine = '';
     if (primary) {
       var cName = ((primary.first_name || '') + ' ' + (primary.last_name || '')).trim();
-      contactLine = '<div class="card-detail">' + TSEB.util.esc(cName) +
-        (primary.phone ? ' · <a href="tel:' + TSEB.util.esc(primary.phone) + '" style="color:var(--primary);" onclick="event.stopPropagation();">' + TSEB.util.esc(primary.phone) + '</a>' : '') +
-        '</div>';
+      if (cName) {
+        contactLine = '<div class="card-contact">&#8627; ' + TSEB.util.esc(cName) + '</div>';
+      }
     }
 
-    return '<div class="' + cardClass + '" style="cursor:pointer;" onclick="TSEB.outreach.showDetail(\'' + i.id + '\')">' +
-      '<div style="display:flex; justify-content:space-between; align-items:flex-start; gap:8px; margin-bottom:6px;">' +
-      '<div class="card-title">' + TSEB.util.esc(i.name) + '</div>' +
-      TSEB.util.statusBadge(i.status) +
+    return '<div class="card outreach-card" onclick="TSEB.outreach.showDetail(\'' + i.id + '\')">' +
+      '<div class="card-head">' +
+      '<h3 class="card-title">' + TSEB.util.esc(i.name) + '</h3>' +
+      TSEB.util.statusPill(i.status, { compact: true }) +
       '</div>' +
-      (i.address || i.zip_code ? '<div class="card-detail">' + TSEB.util.esc(i.address || '') + (i.address && i.zip_code ? ' · ' : '') + (i.zip_code ? TSEB.util.esc(i.zip_code) : '') + '</div>' : '') +
-      contactLine +
+      subtitleHTML +
       nextStepHTML +
-      (outreacherHTML ? '<div style="margin-top:8px;">' + outreacherHTML + '</div>' : '') +
+      contactLine +
       '</div>';
   },
 
@@ -246,126 +228,127 @@ TSEB.outreach = {
       ? Math.floor((new Date() - new Date(inst.next_step_due)) / 86400000)
       : 0;
 
-    // Next step banner
-    let nextStepBanner = '';
-    if (inst.next_step) {
-      nextStepBanner = '<div style="background:' + (overdue ? 'var(--error-light)' : 'var(--accent-light)') + '; border-left:4px solid ' + (overdue ? 'var(--error)' : 'var(--accent)') + '; padding:14px 16px; border-radius:0 var(--radius-sm) var(--radius-sm) 0; margin-bottom:16px;">' +
-        '<div style="font-size:13px; font-weight:700; text-transform:uppercase; letter-spacing:.04em; color:' + (overdue ? 'var(--error)' : 'var(--warning)') + '; margin-bottom:4px;">Next Step</div>' +
-        '<div style="font-size:17px;">' + TSEB.util.esc(inst.next_step) + '</div>' +
-        '<div style="font-size:14px; color:var(--muted); margin-top:6px;">Due: ' + TSEB.util.fmtDate(inst.next_step_due) +
-        (overdue ? ' <strong style="color:var(--error);">· ' + daysOverdue + ' days overdue</strong>' : '') +
-        '</div></div>';
-    }
-
-    // Status change buttons
-    const allStatuses = [
-      { value: 'initial_contact', label: 'Initial Contact' },
-      { value: 'in_conversation', label: 'In Conversation' },
-      { value: 'site_visit', label: 'Site Visit' },
-      { value: 'active', label: 'Active' },
-      { value: 'on_hold', label: 'On Hold' },
-      { value: 'previous', label: 'Previous' },
-      { value: 'inactive', label: 'Inactive' }
-    ];
-    const statusButtons = allStatuses.map(function(s) {
-      const isCurrent = s.value === inst.status;
-      return '<button class="btn ' + (isCurrent ? 'btn-primary' : 'btn-secondary') + '" style="font-size:14px; min-height:40px; padding:8px 14px;' + (isCurrent ? ' cursor:default;' : '') + '" ' +
-        (isCurrent ? 'disabled' : 'onclick="TSEB.outreach.changeStatus(\'' + id + '\', \'' + s.value + '\')"') +
-        '>' + TSEB.util.esc(s.label) + '</button>';
-    }).join('');
-
-    // Contacts section
-    let contactsHTML = '<div style="margin-bottom:20px;">' +
-      '<div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:10px;">' +
-      '<h4 style="font-size:14px; font-weight:700; text-transform:uppercase; letter-spacing:.06em; color:var(--muted); margin:0;">Contacts</h4>' +
-      '<button class="btn btn-secondary" style="font-size:13px; min-height:36px; padding:6px 12px;" onclick="TSEB.outreach.openAddContact(\'' + id + '\')">+ Add Contact</button>' +
-      '</div>';
-    if (contacts && contacts.length) {
-      contactsHTML += contacts.map(function(c) {
-          return '<div style="background:var(--bg); border:1px solid var(--border); border-radius:var(--radius-sm); padding:12px; margin-bottom:8px;">' +
-            '<div style="display:flex; justify-content:space-between; align-items:flex-start;">' +
-            '<div><div style="font-weight:600; font-size:16px;">' + TSEB.util.esc((c.first_name || '') + ' ' + (c.last_name || '')).trim() +
-            (c.is_primary ? ' <span style="font-size:11px; color:var(--accent); font-weight:700;">PRIMARY</span>' : '') + '</div>' +
-            (c.job_title ? '<div style="font-size:14px; color:var(--muted);">' + TSEB.util.esc(c.job_title) + '</div>' : '') +
-            '<div style="font-size:14px; margin-top:4px;">' +
-            (c.phone ? '<a href="tel:' + TSEB.util.esc(c.phone) + '" style="color:var(--primary);">' + TSEB.util.esc(c.phone) + '</a>' : '') +
-            (c.phone && c.email ? ' · ' : '') +
-            (c.email ? '<a href="mailto:' + TSEB.util.esc(c.email) + '" style="color:var(--primary);">' + TSEB.util.esc(c.email) + '</a>' : '') +
-            '</div></div>' +
-            '<button class="btn btn-ghost" style="font-size:12px; min-height:32px; padding:4px 10px; align-self:flex-start;" onclick="event.stopPropagation(); TSEB.outreach.openEditContact(\'' + c.id + '\', \'' + id + '\')">Edit</button>' +
-            '</div></div>';
-        }).join('');
-    } else {
-      contactsHTML += '<p style="color:var(--muted); font-size:15px;">No contacts yet. Add one to track who to call.</p>';
-    }
-    contactsHTML += '</div>';
-
-    // Timeline section
-    let timelineHTML = '';
-    if (activities && activities.length) {
-      timelineHTML = activities.map(function(a) {
-        const isAction = ['phone_call','voicemail','email_sent','email_received','in_person','site_visit','first_sing'].includes(a.activity_type);
-        const isStatus = a.activity_type === 'status_change';
-        const dotColor = isStatus ? 'var(--info)' : isAction ? 'var(--primary)' : 'var(--muted)';
-        const typeLabel = (a.activity_type || '').replace(/_/g, ' ').replace(/\b\w/g, function(c) { return c.toUpperCase(); });
-        return '<div style="display:flex; gap:12px; margin-bottom:16px;">' +
-          '<div style="flex-shrink:0; width:10px; height:10px; border-radius:50%; background:' + dotColor + '; margin-top:6px;"></div>' +
-          '<div style="flex:1;">' +
-          '<div style="font-size:13px; color:var(--muted); margin-bottom:2px;">' +
-          TSEB.util.fmtDate(a.activity_date) +
-          (a.singer ? ' · ' + TSEB.util.esc(a.singer.first_name) : '') +
-          ' · <em>' + TSEB.util.esc(typeLabel) + '</em>' +
-          '</div>' +
-          '<div style="font-size:15px;">' + TSEB.util.esc(a.description) + '</div>' +
-          '</div></div>';
-      }).join('');
-    } else {
-      timelineHTML = '<p style="color:var(--muted); font-size:15px;">No activity logged yet. Tap Log Activity to get started.</p>';
-    }
-
     const typeLabel = inst.institution_type
       ? inst.institution_type.replace(/_/g, ' ').replace(/\b\w/g, function(c) { return c.toUpperCase(); })
       : '';
 
+    // Eyebrow line: type · address · zip
+    const eyebrowParts = [];
+    if (typeLabel) eyebrowParts.push(TSEB.util.esc(typeLabel));
+    if (inst.address) eyebrowParts.push(TSEB.util.esc(inst.address));
+    if (inst.zip_code) eyebrowParts.push(TSEB.util.esc(inst.zip_code));
+    const eyebrowHTML = eyebrowParts.length
+      ? '<div class="eyebrow detail-eyebrow">' + eyebrowParts.join(' &middot; ') + '</div>'
+      : '';
+
+    // Status pill row (all statuses, current is active)
+    const allStatuses = ['initial_contact','in_conversation','site_visit','active','on_hold','previous','inactive'];
+    const statusRow = allStatuses.map(function(s) {
+      const isCurrent = s === inst.status;
+      const onClick = isCurrent ? '' : ' onclick="TSEB.outreach.changeStatus(\'' + id + '\', \'' + s + '\')"';
+      return TSEB.util.statusPill(s, { active: isCurrent, attrs: onClick });
+    }).join(' ');
+
+    // Next-action banner — paper-2 background, italic display body
+    let nextActionHTML = '';
+    if (inst.next_step) {
+      const dueText = overdue
+        ? 'Overdue · ' + daysOverdue + ' day' + (daysOverdue === 1 ? '' : 's')
+        : 'Due ' + TSEB.util.fmtDate(inst.next_step_due);
+      nextActionHTML =
+        '<div class="detail-next-action">' +
+        '<div class="eyebrow detail-next-eyebrow' + (overdue ? ' is-overdue' : '') + '">Next action &middot; ' + TSEB.util.esc(dueText) + '</div>' +
+        '<div class="detail-next-body">' + TSEB.util.esc(inst.next_step) + '</div>' +
+        '<button class="btn btn-accent detail-next-cta" onclick="TSEB.outreach.openLogActivity(\'' + id + '\')">Log activity</button>' +
+        '</div>';
+    } else {
+      nextActionHTML =
+        '<div class="detail-next-action">' +
+        '<div class="eyebrow">No next step set</div>' +
+        '<button class="btn btn-accent detail-next-cta" onclick="TSEB.outreach.openLogActivity(\'' + id + '\')">Log activity</button>' +
+        '</div>';
+    }
+
+    // Contacts (line items, dotted divider between)
+    let contactsHTML = '<div class="detail-section">' +
+      '<div class="detail-section-head">' +
+      '<div class="eyebrow">Contacts</div>' +
+      '<button class="detail-section-action" onclick="TSEB.outreach.openAddContact(\'' + id + '\')">+ Add</button>' +
+      '</div>';
+    if (contacts && contacts.length) {
+      contactsHTML += contacts.map(function(c, i) {
+        const cName = ((c.first_name || '') + ' ' + (c.last_name || '')).trim();
+        const titleHTML = c.job_title
+          ? '<span class="smcaps faint">' + TSEB.util.esc(c.job_title) + (c.is_primary ? ' &middot; primary' : '') + '</span>'
+          : (c.is_primary ? '<span class="smcaps faint">primary</span>' : '');
+        const phoneHTML = c.phone
+          ? '<a class="detail-contact-phone" href="tel:' + TSEB.util.esc(c.phone) + '" onclick="event.stopPropagation();">' + TSEB.util.esc(c.phone) + '</a>'
+          : '';
+        const emailHTML = c.email
+          ? '<a class="detail-contact-email" href="mailto:' + TSEB.util.esc(c.email) + '" onclick="event.stopPropagation();">' + TSEB.util.esc(c.email) + '</a>'
+          : '';
+        return '<div class="detail-contact" onclick="TSEB.outreach.openEditContact(\'' + c.id + '\', \'' + id + '\')">' +
+          '<div class="detail-contact-row">' +
+          '<span class="detail-contact-name">' + TSEB.util.esc(cName) + '</span>' +
+          titleHTML +
+          '</div>' +
+          (phoneHTML || emailHTML
+            ? '<div class="detail-contact-meta">' + phoneHTML + (phoneHTML && emailHTML ? '<span class="meta-sep">·</span>' : '') + emailHTML + '</div>'
+            : '') +
+          '</div>';
+      }).join('');
+    } else {
+      contactsHTML += '<div class="detail-empty">No contacts yet.</div>';
+    }
+    contactsHTML += '</div>';
+
+    // Timeline
+    let timelineHTML = '<div class="detail-section">' +
+      '<div class="detail-section-head"><div class="eyebrow">Timeline</div></div>';
+    if (activities && activities.length) {
+      timelineHTML += '<div class="detail-timeline">' + activities.map(function(a) {
+        const tLabel = (a.activity_type || '').replace(/_/g, ' ').replace(/\b\w/g, function(c) { return c.toUpperCase(); });
+        const dateShort = TSEB.util.fmtDateShort(a.activity_date);
+        return '<div class="detail-timeline-row">' +
+          '<div class="detail-timeline-date">' +
+          '<div class="smcaps faint">' + TSEB.util.esc(dateShort) + '</div>' +
+          '<div class="smcaps detail-timeline-type">' + TSEB.util.esc(tLabel) + '</div>' +
+          '</div>' +
+          '<div class="detail-timeline-rule"><span class="dot"></span></div>' +
+          '<div class="detail-timeline-note">' + TSEB.util.esc(a.description || '') +
+          (a.singer ? ' <span class="smcaps faint">&middot; ' + TSEB.util.esc(a.singer.first_name) + '</span>' : '') +
+          '</div>' +
+          '</div>';
+      }).join('') + '</div>';
+    } else {
+      timelineHTML += '<div class="detail-empty">No activity logged yet.</div>';
+    }
+    timelineHTML += '</div>';
+
+    const notesHTML = inst.notes
+      ? '<div class="detail-section">' +
+          '<div class="detail-section-head"><div class="eyebrow">Notes</div></div>' +
+          '<div class="detail-notes">' + TSEB.util.esc(inst.notes) + '</div>' +
+        '</div>'
+      : '';
+
     const html =
-      '<div class="modal-header">' +
-      '<button class="modal-back-btn" onclick="TSEB.closeDetail()" aria-label="Close">&#8592;</button>' +
-      '<div class="modal-title">' + TSEB.util.esc(inst.name) + '</div>' +
+      '<div class="detail-topbar">' +
+      '<button class="topbar-link" onclick="TSEB.closeDetail()" aria-label="Close">&larr; Outreach</button>' +
+      '<button class="topbar-link topbar-link-accent" onclick="TSEB.outreach.openEditForm(\'' + id + '\')">Edit</button>' +
       '</div>' +
-      '<div class="modal-body">' +
-      '<div style="margin-bottom:16px;">' +
-      (typeLabel ? '<div style="font-size:15px; color:var(--muted);">' + TSEB.util.esc(typeLabel) + '</div>' : '') +
-      (inst.address || inst.zip_code ? '<div style="font-size:15px; color:var(--muted);">' + TSEB.util.esc(inst.address || '') + (inst.address && inst.zip_code ? ' · ' : '') + (inst.zip_code ? TSEB.util.esc(inst.zip_code) : '') + '</div>' : '') +
-      '<div style="margin-top:8px;">' + TSEB.util.statusBadge(inst.status) + '</div>' +
+      '<div class="detail-body">' +
+      '<div class="detail-hero">' +
+      eyebrowHTML +
+      '<h1 class="detail-title">' + TSEB.util.esc(inst.name) + '</h1>' +
+      '<div class="detail-status-row">' + statusRow + '</div>' +
       '</div>' +
-
-      nextStepBanner +
-
-      '<div style="display:flex; gap:10px; margin-bottom:20px;">' +
-      '<button class="btn btn-primary" style="flex:1;" onclick="TSEB.outreach.openLogActivity(\'' + id + '\')">Log Activity</button>' +
-      '<button class="btn btn-secondary" onclick="TSEB.outreach.openEditForm(\'' + id + '\')">Edit</button>' +
-      '</div>' +
-
-      (inst.outreacher
-        ? '<div style="margin-bottom:16px;"><span style="font-size:14px; color:var(--muted); margin-right:8px;">Outreacher:</span>' + TSEB.util.singerChip(inst.outreacher.first_name) + '</div>'
-        : '') +
-
+      '<hr class="h-rule">' +
+      nextActionHTML +
       contactsHTML +
-
-      '<div style="margin-bottom:20px;">' +
-      '<h4 style="font-size:14px; font-weight:700; text-transform:uppercase; letter-spacing:.06em; color:var(--muted); margin-bottom:10px;">Change Status</h4>' +
-      '<div style="display:flex; flex-wrap:wrap; gap:8px;">' + statusButtons + '</div>' +
-      '</div>' +
-
-      '<div style="margin-bottom:20px;">' +
-      '<h4 style="font-size:14px; font-weight:700; text-transform:uppercase; letter-spacing:.06em; color:var(--muted); margin-bottom:10px;">Timeline</h4>' +
+      '<hr class="h-rule">' +
       timelineHTML +
-      '</div>' +
-
-      (inst.notes
-        ? '<div style="margin-bottom:20px;"><h4 style="font-size:14px; font-weight:700; text-transform:uppercase; letter-spacing:.06em; color:var(--muted); margin-bottom:10px;">Notes</h4><p style="font-size:15px;">' + TSEB.util.esc(inst.notes) + '</p></div>'
-        : '') +
-
+      notesHTML +
       '</div>';
 
     TSEB.showDetail(html);
@@ -679,73 +662,78 @@ TSEB.outreach = {
     const inst = this._data ? this._data.find(function(i) { return i.id === institutionId; }) : null;
     const instName = inst ? inst.name : 'Facility';
 
+    // Activity type buttons (status-pill style)
+    const activityTypes = [
+      { value: 'phone_call', label: 'Call' },
+      { value: 'email_sent', label: 'Email' },
+      { value: 'in_person', label: 'Visit' },
+      { value: 'site_visit', label: 'Site Visit' },
+      { value: 'voicemail', label: 'Voicemail' },
+      { value: 'note', label: 'Note' }
+    ];
+    const typeButtons = activityTypes.map(function(t) {
+      return '<button type="button" class="status-pill activity-type-btn" data-value="' + t.value +
+        '" onclick="TSEB.outreach._pickActivityType(this)">' +
+        '<span class="dot"></span>' + t.label + '</button>';
+    }).join('');
+
     const html =
-      '<div class="modal-header">' +
-      '<button class="modal-back-btn" onclick="TSEB.closeForm(); TSEB.outreach.showDetail(\'' + institutionId + '\')" aria-label="Back">&#8592;</button>' +
-      '<div class="modal-title">Log Activity</div>' +
+      '<div class="form-topbar">' +
+      '<button type="button" class="topbar-link" onclick="TSEB.closeForm(); TSEB.outreach.showDetail(\'' + institutionId + '\')">Cancel</button>' +
+      '<button type="submit" form="log-activity-form" class="topbar-link topbar-link-accent">Save</button>' +
       '</div>' +
-      '<div class="modal-body">' +
-      '<div style="font-size:15px; color:var(--muted); margin-bottom:20px;">For: <strong style="color:var(--text);">' + TSEB.util.esc(instName) + '</strong></div>' +
+      '<div class="form-body">' +
       '<form id="log-activity-form" onsubmit="event.preventDefault(); TSEB.outreach.submitLogActivity(this);">' +
       '<input type="hidden" name="institution_id" value="' + institutionId + '">' +
+      '<input type="hidden" name="activity_type" id="log-activity-type" required value="phone_call">' +
 
-      '<div class="form-group">' +
-      '<label class="form-label" for="log-singer">Who did this?</label>' +
-      '<select id="log-singer" name="singer_id" class="form-select">' +
-      '<option value="">Select singer...</option>' + singerOptions +
+      '<div class="eyebrow">Logging activity at</div>' +
+      '<h1 class="form-title">' + TSEB.util.esc(instName) + '</h1>' +
+
+      '<label class="eyebrow form-eyebrow-label">Type</label>' +
+      '<div class="form-pill-row">' + typeButtons + '</div>' +
+
+      '<label class="eyebrow form-eyebrow-label">Who did this?</label>' +
+      '<select name="singer_id" class="form-select form-select-bare">' +
+      '<option value="">Choose singer&hellip;</option>' + singerOptions +
       '</select>' +
+
+      '<label class="eyebrow form-eyebrow-label">Contact at the facility</label>' +
+      '<input name="contact_person" type="text" class="form-input" placeholder="Name (optional)">' +
+
+      '<label class="eyebrow form-eyebrow-label">What happened?</label>' +
+      '<textarea name="description" class="form-input form-textarea" rows="3" required placeholder="A few words about the interaction&hellip;"></textarea>' +
+
+      '<label class="eyebrow form-eyebrow-label">Date</label>' +
+      '<input name="activity_date" type="date" class="form-input form-input-display" value="' + today + '" required>' +
+
+      '<div class="form-next-step-block">' +
+      '<div class="eyebrow form-next-step-eyebrow">Next step (optional)</div>' +
+      '<input name="next_step" type="text" class="form-input form-input-italic" placeholder="What happens next?">' +
+      '<label class="smcaps faint form-next-step-due-label">Due</label>' +
+      '<input name="next_step_due" type="date" class="form-input form-input-italic">' +
       '</div>' +
 
-      '<div class="form-group">' +
-      '<label class="form-label" for="log-type">Activity Type *</label>' +
-      '<select id="log-type" name="activity_type" class="form-select" required>' +
-      '<option value="">Select type...</option>' +
-      '<option value="phone_call">Phone Call</option>' +
-      '<option value="voicemail">Voicemail</option>' +
-      '<option value="email_sent">Email Sent</option>' +
-      '<option value="email_received">Email Received</option>' +
-      '<option value="in_person">In Person</option>' +
-      '<option value="site_visit">Site Visit</option>' +
-      '<option value="first_sing">First Sing</option>' +
-      '<option value="status_change">Status Change</option>' +
-      '<option value="note">Note</option>' +
-      '</select>' +
-      '</div>' +
-
-      '<div class="form-group">' +
-      '<label class="form-label" for="log-date">Date *</label>' +
-      '<input id="log-date" name="activity_date" type="date" class="form-input" value="' + today + '" required>' +
-      '</div>' +
-
-      '<div class="form-group">' +
-      '<label class="form-label" for="log-contact">Who did you speak with?</label>' +
-      '<input id="log-contact" name="contact_person" type="text" class="form-input" placeholder="Name at the facility">' +
-      '</div>' +
-
-      '<div class="form-group">' +
-      '<label class="form-label" for="log-desc">What happened? *</label>' +
-      '<textarea id="log-desc" name="description" class="form-input" rows="4" placeholder="Describe the interaction..." required></textarea>' +
-      '</div>' +
-
-      '<details style="margin-bottom:16px;">' +
-      '<summary style="font-size:16px; font-weight:600; cursor:pointer; padding:8px 0; color:var(--primary);">Update next step (optional)</summary>' +
-      '<div style="margin-top:12px;">' +
-      '<div class="form-group">' +
-      '<label class="form-label" for="log-next-step">Next Step</label>' +
-      '<input id="log-next-step" name="next_step" type="text" class="form-input" placeholder="What happens next?">' +
-      '</div>' +
-      '<div class="form-group">' +
-      '<label class="form-label" for="log-next-due">Due Date</label>' +
-      '<input id="log-next-due" name="next_step_due" type="date" class="form-input">' +
-      '</div>' +
-      '</div></details>' +
-
-      '<button type="submit" class="btn btn-primary" style="width:100%;">Save Activity</button>' +
+      '<button type="submit" class="btn btn-accent form-submit">Save activity</button>' +
       '</form>' +
       '</div>';
 
     TSEB.closeDetail();
     TSEB.showForm(html);
+
+    // Mark first activity-type pill as active by default
+    setTimeout(function() {
+      const first = document.querySelector('.activity-type-btn[data-value="phone_call"]');
+      if (first) first.classList.add('is-active');
+    }, 50);
+  },
+
+  _pickActivityType: function(btn) {
+    const all = document.querySelectorAll('.activity-type-btn');
+    all.forEach(function(b) { b.classList.remove('is-active'); });
+    btn.classList.add('is-active');
+    const hidden = document.getElementById('log-activity-type');
+    if (hidden) hidden.value = btn.dataset.value;
   },
 
   async submitLogActivity(form) {

--- a/js/schedule.js
+++ b/js/schedule.js
@@ -1,18 +1,52 @@
-// TSEB Schedule module — calendar + list view, add gig
+// TSEB Schedule module — Plainchant: Calendar / Agenda / Map view picker
 TSEB.schedule = {
   _loaded: false,
   _data: null,
   _calMonth: new Date().getMonth(),
   _calYear: new Date().getFullYear(),
-  _calGigs: [],
+  _view: null,
+  _map: null,
+  _institutions: null,
+
+  // East Bay zip code centroids — used to plot gigs on the map.
+  _zipCoords: {
+    '94563': { lat: 37.8809, lng: -122.1797 },
+    '94568': { lat: 37.7022, lng: -121.9358 },
+    '94577': { lat: 37.7164, lng: -122.1525 },
+    '94578': { lat: 37.7044, lng: -122.1131 },
+    '94601': { lat: 37.7740, lng: -122.2202 },
+    '94602': { lat: 37.8027, lng: -122.2078 },
+    '94609': { lat: 37.8338, lng: -122.2649 },
+    '94611': { lat: 37.8309, lng: -122.2364 },
+    '94612': { lat: 37.8088, lng: -122.2691 },
+    '94704': { lat: 37.8669, lng: -122.2587 },
+    '94705': { lat: 37.8584, lng: -122.2470 },
+    '94706': { lat: 37.8908, lng: -122.2965 }
+  },
+
+  _readView: function() {
+    try { return localStorage.getItem('tseb-schedule-view') || 'calendar'; }
+    catch (e) { return 'calendar'; }
+  },
+
+  _writeView: function(v) {
+    try { localStorage.setItem('tseb-schedule-view', v); } catch (e) {}
+  },
+
+  setView: function(v) {
+    this._view = v;
+    this._writeView(v);
+    this._render();
+  },
 
   async load() {
     this._loaded = true;
+    this._view = this._readView();
     TSEB.showSkeleton('schedule-list', 4);
 
     var today = TSEB.util.todayStr();
     var { data: gigs, error } = await TSEB.sb.from('gigs')
-      .select('*, institution:institutions(id, name, address, institution_type, contacts(first_name, last_name, job_title, phone, email, is_primary)), gig_singers(singer_id, is_anchor)')
+      .select('*, institution:institutions(id, name, address, zip_code, institution_type, contacts(first_name, last_name, job_title, phone, email, is_primary)), gig_singers(singer_id, is_anchor)')
       .gte('gig_date', today)
       .order('gig_date')
       .order('gig_time');
@@ -26,261 +60,393 @@ TSEB.schedule = {
 
     this._data = gigs || [];
     this._render();
-    this._loadCalendar(this._calYear, this._calMonth);
   },
 
-  _render() {
+  _render: function() {
     var el = document.getElementById('schedule-list');
     if (!el) return;
 
-    // Calendar container + list below
-    var html = '<div id="cal-container" style="margin-bottom:24px;"></div>';
+    var picker = this._pickerHTML();
 
     if (!this._data || this._data.length === 0) {
-      html += '<div class="empty-state">' +
+      el.innerHTML = picker +
+        '<div class="empty-state">' +
         '<div class="empty-state-title">No upcoming gigs</div>' +
         '<div class="empty-state-body">No singing sessions scheduled yet. Tap + to add a gig.</div>' +
         '</div>';
-    } else {
-      // Group by month
-      var byMonth = {};
-      this._data.forEach(function(g) {
-        var month = g.gig_date.slice(0, 7);
-        if (!byMonth[month]) byMonth[month] = [];
-        byMonth[month].push(g);
-      });
-
-      html += Object.keys(byMonth).sort().map(function(month) {
-        var dt = new Date(month + '-01T00:00:00');
-        var monthLabel = dt.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
-        var gigs = byMonth[month];
-
-        var gigsHTML = gigs.map(function(g) {
-          var gigDt = new Date(g.gig_date + 'T00:00:00');
-          var timeStr = g.gig_time ? TSEB.util.fmtTime(g.gig_time) : '';
-          var singers = (g.gig_singers || []).map(function(gs) {
-            var name = TSEB.util.singerName(gs.singer_id);
-            return gs.is_anchor
-              ? '<span class="singer-chip">' + TSEB.util.esc(name) + ' <span style="font-size:11px; opacity:.7;">anchor</span></span>'
-              : TSEB.util.singerChip(name);
-          });
-
-          return '<div class="card" style="cursor:pointer; margin-bottom:12px;" onclick="TSEB.schedule.showGigDetail(\'' + g.id + '\')">' +
-            '<div style="display:flex; align-items:flex-start; gap:12px;">' +
-            '<div style="text-align:center; min-width:48px; background:var(--primary-light); border-radius:var(--radius-sm); padding:6px 8px;">' +
-            '<div style="font-size:12px; font-weight:700; text-transform:uppercase; color:var(--primary);">' + gigDt.toLocaleDateString('en-US', { weekday: 'short' }) + '</div>' +
-            '<div style="font-size:22px; font-weight:700; color:var(--primary); line-height:1.1;">' + gigDt.getDate() + '</div>' +
-            '</div>' +
-            '<div style="flex:1;">' +
-            '<div class="card-title" style="font-size:18px;">' + TSEB.util.esc(g.institution ? g.institution.name : 'Unknown Venue') + '</div>' +
-            '<div class="card-detail">' +
-            (timeStr ? timeStr + ' · ' : '') +
-            TSEB.util.recurrenceLabel(g.recurrence) +
-            (g.institution && g.institution.address ? ' · ' + TSEB.util.esc(g.institution.address) : '') +
-            '</div>' +
-            (singers.length
-              ? '<div style="display:flex; flex-wrap:wrap; gap:4px; margin-top:8px;">' + singers.join('') + '</div>'
-              : '') +
-            (g.notes ? '<div style="font-size:14px; color:var(--muted); margin-top:6px; font-style:italic;">' + TSEB.util.esc(g.notes) + '</div>' : '') +
-            '</div>' +
-            '</div>' +
-            '</div>';
-        }).join('');
-
-        return '<div style="margin-bottom:8px;">' +
-          '<h2 style="font-family:var(--font-display); font-size:20px; font-weight:600; color:var(--text); padding:16px 0 10px; border-bottom:2px solid var(--border); margin-bottom:12px;">' +
-          TSEB.util.esc(monthLabel) + ' <span style="font-size:15px; font-weight:400; color:var(--muted);">(' + gigs.length + ' gig' + (gigs.length !== 1 ? 's' : '') + ')</span>' +
-          '</h2>' +
-          gigsHTML +
-          '</div>';
-      }).join('');
+      return;
     }
 
-    el.innerHTML = html;
+    var body = '';
+    if (this._view === 'agenda') body = this._agendaHTML();
+    else if (this._view === 'map') body = this._mapHTML();
+    else body = this._calendarHTML();
+
+    el.innerHTML = picker + body;
+
+    // Map needs to be initialized after the DOM is in place.
+    if (this._view === 'map') this._initMap();
+  },
+
+  _pickerHTML: function() {
+    var view = this._view;
+    var opts = [
+      { id: 'calendar', label: 'Calendar' },
+      { id: 'agenda',   label: 'Agenda' },
+      { id: 'map',      label: 'Map' }
+    ];
+    var btns = opts.map(function(o) {
+      var cls = 'sched-picker-btn' + (view === o.id ? ' is-active' : '');
+      return '<button class="' + cls + '" onclick="TSEB.schedule.setView(\'' + o.id + '\')">' +
+        TSEB.util.esc(o.label) + '</button>';
+    }).join('');
+
+    return '<div class="sched-picker">' +
+      '<div class="eyebrow">Your schedule view</div>' +
+      '<div class="sched-picker-grid">' + btns + '</div>' +
+      '<div class="sched-picker-hint">Tap to switch &middot; we\'ll remember your favorite</div>' +
+      '</div>';
   },
 
   // ============================================================
-  // CALENDAR
+  // CALENDAR VIEW
   // ============================================================
   _localDateStr: function(d) {
     return d.getFullYear() + '-' + String(d.getMonth() + 1).padStart(2, '0') + '-' + String(d.getDate()).padStart(2, '0');
   },
 
-  async _loadCalendar(year, month) {
-    this._calYear = year;
-    this._calMonth = month;
-
+  _calendarHTML: function() {
+    var year = this._calYear, month = this._calMonth;
     var first = new Date(year, month, 1);
     var last = new Date(year, month + 1, 0);
-    var startDay = new Date(first);
-    startDay.setDate(startDay.getDate() - first.getDay());
-    var endDay = new Date(last);
-    endDay.setDate(endDay.getDate() + (6 - last.getDay()));
-
-    var { data: gigs } = await TSEB.sb.from('gigs')
-      .select('*, institution:institutions(name, address), gig_singers(singer_id, is_anchor)')
-      .gte('gig_date', this._localDateStr(startDay))
-      .lte('gig_date', this._localDateStr(endDay))
-      .order('gig_time');
-
-    this._calGigs = gigs || [];
-    this._renderCalendar();
-  },
-
-  _renderCalendar: function() {
-    var container = document.getElementById('cal-container');
-    if (!container) return;
-
-    var today = this._localDateStr(new Date());
-    var first = new Date(this._calYear, this._calMonth, 1);
-    var last = new Date(this._calYear, this._calMonth + 1, 0);
     var monthLabel = first.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+    var todayStr = this._localDateStr(new Date());
 
-    // Gigs by date
+    var prevMonth = new Date(year, month - 1, 1);
+    var nextMonth = new Date(year, month + 1, 1);
+    var prevLabel = prevMonth.toLocaleDateString('en-US', { month: 'short' });
+    var nextLabel = nextMonth.toLocaleDateString('en-US', { month: 'short' });
+
+    // Gigs by date for THIS month grid.
+    var monthFirst = this._localDateStr(first);
+    var monthLast = this._localDateStr(last);
     var gigsByDate = {};
-    this._calGigs.forEach(function(g) {
-      if (!gigsByDate[g.gig_date]) gigsByDate[g.gig_date] = [];
-      gigsByDate[g.gig_date].push(g);
+    this._data.forEach(function(g) {
+      if (g.gig_date >= monthFirst && g.gig_date <= monthLast) {
+        if (!gigsByDate[g.gig_date]) gigsByDate[g.gig_date] = [];
+        gigsByDate[g.gig_date].push(g);
+      }
     });
 
-    // Navigation
-    var html = '<div style="display:flex; align-items:center; justify-content:space-between; padding:12px 0;">' +
-      '<button class="btn btn-ghost" style="min-height:40px; padding:8px 14px;" onclick="TSEB.schedule.calPrev()">&lsaquo; Prev</button>' +
-      '<span style="font-family:var(--font-display); font-size:20px; font-weight:600;">' + TSEB.util.esc(monthLabel) + '</span>' +
-      '<button class="btn btn-ghost" style="min-height:40px; padding:8px 14px;" onclick="TSEB.schedule.calNext()">Next &rsaquo;</button>' +
+    var html = '<div class="sched-cal-head">' +
+      '<button class="sched-cal-nav" onclick="TSEB.schedule.calPrev()">&lsaquo; ' + TSEB.util.esc(prevLabel) + '</button>' +
+      '<div class="sched-cal-month">' +
+        '<div class="eyebrow">In the month of</div>' +
+        '<h2 class="sched-cal-month-name">' + TSEB.util.esc(monthLabel) + '</h2>' +
+      '</div>' +
+      '<button class="sched-cal-nav" onclick="TSEB.schedule.calNext()">' + TSEB.util.esc(nextLabel) + ' &rsaquo;</button>' +
       '</div>';
 
-    // Grid
-    html += '<div style="display:grid; grid-template-columns:repeat(7,1fr); gap:1px; background:var(--border); border:1px solid var(--border); border-radius:var(--radius-md); overflow:hidden;">';
-
-    // Day headers
-    ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'].forEach(function(d) {
-      html += '<div style="background:var(--primary-light); padding:6px 4px; text-align:center; font-size:12px; font-weight:700; color:var(--primary); text-transform:uppercase;">' + d + '</div>';
+    html += '<div class="sched-cal-grid">';
+    ['S','M','T','W','T','F','S'].forEach(function(d) {
+      html += '<div class="sched-cal-dow">' + d + '</div>';
     });
 
-    // Cells
-    var cursor = new Date(this._calYear, this._calMonth, 1);
-    cursor.setDate(cursor.getDate() - first.getDay());
-    var totalCells = Math.ceil((first.getDay() + last.getDate()) / 7) * 7;
-
-    for (var i = 0; i < totalCells; i++) {
-      var dateStr = this._localDateStr(cursor);
-      var isOther = cursor.getMonth() !== this._calMonth;
-      var isToday = dateStr === today;
+    // Leading blanks for first.getDay() (0=Sun)
+    var startBlanks = first.getDay();
+    for (var b = 0; b < startBlanks; b++) {
+      html += '<div class="sched-cal-cell is-other"></div>';
+    }
+    var daysInMonth = last.getDate();
+    for (var d = 1; d <= daysInMonth; d++) {
+      var dateStr = year + '-' + String(month + 1).padStart(2, '0') + '-' + String(d).padStart(2, '0');
+      var isToday = dateStr === todayStr;
       var dayGigs = gigsByDate[dateStr] || [];
-
-      var bg = isToday ? 'var(--accent-light)' : 'var(--surface)';
-      var opacity = isOther ? '0.4' : '1';
-
-      html += '<div style="background:' + bg + '; padding:4px; min-height:60px; opacity:' + opacity + ';">';
-      html += '<div style="font-size:13px; font-weight:' + (isToday ? '700' : '400') + '; color:' + (isToday ? 'var(--accent)' : 'var(--text)') + ';">' + cursor.getDate() + '</div>';
-
-      dayGigs.forEach(function(g) {
-        var timeLabel = g.gig_time ? TSEB.util.fmtTime(g.gig_time) + ' ' : '';
-        var tooltip = TSEB.util.esc((g.institution ? g.institution.name : '') + (g.gig_time ? ' at ' + g.gig_time.slice(0, 5) : '') + (g.institution && g.institution.address ? '\n' + g.institution.address : ''));
-        html += '<div style="font-size:11px; background:var(--primary-light); color:var(--primary); padding:1px 4px; border-radius:3px; margin-top:2px; cursor:pointer; white-space:nowrap; overflow:hidden; text-overflow:ellipsis;" ' +
-          'onclick="TSEB.schedule.showGigDetail(\'' + g.id + '\')" title="' + tooltip + '">' +
-          timeLabel + TSEB.util.esc(g.institution ? g.institution.name : '?') +
-          '</div>';
-      });
-
-      html += '</div>';
-      cursor.setDate(cursor.getDate() + 1);
+      var has = dayGigs.length > 0;
+      var cls = 'sched-cal-cell';
+      if (isToday) cls += ' is-today';
+      if (has) cls += ' has-gig';
+      var click = has ? ' onclick="TSEB.schedule.showGigDetail(\'' + dayGigs[0].id + '\')"' : '';
+      html += '<div class="' + cls + '"' + click + '>' +
+        '<span class="sched-cal-num">' + d + '</span>' +
+        (has ? '<span class="sched-cal-dot"></span>' : '') +
+        '</div>';
     }
 
     html += '</div>';
-    container.innerHTML = html;
+
+    // Upcoming list below grid — for current and future months only.
+    var todayD = new Date();
+    todayD.setHours(0, 0, 0, 0);
+    var upcoming = this._data.filter(function(g) {
+      var dt = new Date(g.gig_date + 'T00:00:00');
+      return dt >= todayD;
+    }).slice(0, 6);
+
+    if (upcoming.length) {
+      html += '<hr class="h-rule" style="margin:12px 22px;"/>';
+      html += '<div class="sched-upcoming">';
+      html += '<div class="eyebrow sched-upcoming-eyebrow">Upcoming gigs</div>';
+      html += upcoming.map(function(g) { return TSEB.schedule._upcomingRow(g); }).join('');
+      html += '</div>';
+    }
+
+    return html;
+  },
+
+  _upcomingRow: function(g) {
+    var dt = new Date(g.gig_date + 'T00:00:00');
+    var dow = dt.toLocaleDateString('en-US', { weekday: 'short' });
+    var day = dt.getDate();
+    var timeStr = g.gig_time ? TSEB.util.fmtTime(g.gig_time) : '';
+    var venue = g.institution ? g.institution.name : 'Unknown venue';
+    var singerCount = (g.gig_singers || []).length;
+    var meta = (timeStr ? timeStr : '') +
+      (timeStr && singerCount ? ' &middot; ' : '') +
+      (singerCount ? singerCount + ' singer' + (singerCount === 1 ? '' : 's') : '');
+
+    var singers = (g.gig_singers || []).map(function(gs) {
+      return '<span class="sched-singer-chip">' + TSEB.util.esc(TSEB.util.singerName(gs.singer_id)) + '</span>';
+    }).join('');
+
+    return '<div class="sched-upcoming-row" onclick="TSEB.schedule.showGigDetail(\'' + g.id + '\')">' +
+      '<div class="sched-upcoming-date">' +
+        '<div class="sched-upcoming-dow">' + TSEB.util.esc(dow) + '</div>' +
+        '<div class="sched-upcoming-day">' + day + '</div>' +
+      '</div>' +
+      '<div class="sched-upcoming-body">' +
+        '<div class="sched-upcoming-venue">' + TSEB.util.esc(venue) + '</div>' +
+        '<div class="sched-upcoming-meta">' + meta + '</div>' +
+        (singers ? '<div class="sched-upcoming-singers">' + singers + '</div>' : '') +
+      '</div>' +
+      '</div>';
   },
 
   calPrev: function() {
     var m = this._calMonth - 1, y = this._calYear;
     if (m < 0) { m = 11; y--; }
-    this._loadCalendar(y, m);
+    this._calYear = y;
+    this._calMonth = m;
+    this._render();
   },
 
   calNext: function() {
     var m = this._calMonth + 1, y = this._calYear;
     if (m > 11) { m = 0; y++; }
-    this._loadCalendar(y, m);
+    this._calYear = y;
+    this._calMonth = m;
+    this._render();
   },
 
   // ============================================================
-  // ADD GIG FORM
+  // AGENDA VIEW
+  // ============================================================
+  _agendaHTML: function() {
+    var todayD = new Date();
+    todayD.setHours(0, 0, 0, 0);
+    var list = this._data.filter(function(g) {
+      var dt = new Date(g.gig_date + 'T00:00:00');
+      return dt >= todayD;
+    });
+
+    var html = '<div class="sched-agenda-head">' +
+      '<div class="eyebrow sched-agenda-eyebrow">Schedule</div>' +
+      '<h2 class="sched-agenda-title">The coming weeks</h2>' +
+      '</div>';
+
+    if (!list.length) {
+      html += '<div class="empty-state">' +
+        '<div class="empty-state-title">No upcoming gigs</div>' +
+        '<div class="empty-state-body">Tap + to schedule one.</div>' +
+        '</div>';
+      return html;
+    }
+
+    html += '<div class="sched-tl-list">' +
+      list.map(function(g) { return TSEB.schedule._timelineRow(g, null); }).join('') +
+      '</div>';
+
+    return html;
+  },
+
+  _timelineRow: function(g, num) {
+    var dt = new Date(g.gig_date + 'T00:00:00');
+    var monthShort = dt.toLocaleDateString('en-US', { month: 'short' });
+    var day = dt.getDate();
+    var dow = dt.toLocaleDateString('en-US', { weekday: 'long' });
+    var timeStr = g.gig_time ? TSEB.util.fmtTime(g.gig_time) : '';
+    var venue = g.institution ? g.institution.name : 'Unknown venue';
+    var rec = TSEB.util.recurrenceLabel(g.recurrence) || '';
+    var meta = (timeStr ? timeStr : '') +
+      (timeStr && rec ? ' &middot; ' : '') +
+      (rec ? rec : '');
+
+    var singerNames = (g.gig_singers || []).map(function(gs) {
+      return TSEB.util.singerName(gs.singer_id);
+    }).join(' &middot; ');
+
+    var ruleCls = 'sched-tl-rule' + (num != null ? ' is-numbered' : '');
+    var ruleAttrs = num != null ? ' data-num="' + num + '"' : '';
+
+    return '<div class="sched-tl-row" onclick="TSEB.schedule.showGigDetail(\'' + g.id + '\')">' +
+      '<div class="sched-tl-date">' +
+        '<div class="sched-tl-month">' + TSEB.util.esc(monthShort) + '</div>' +
+        '<div class="sched-tl-day">' + day + '</div>' +
+        '<div class="sched-tl-dow">' + TSEB.util.esc(dow) + '</div>' +
+      '</div>' +
+      '<div class="' + ruleCls + '"' + ruleAttrs + '></div>' +
+      '<div class="sched-tl-body">' +
+        '<div class="sched-tl-venue">' + TSEB.util.esc(venue) + '</div>' +
+        '<div class="sched-tl-meta">' + meta + '</div>' +
+        (singerNames ? '<div class="sched-tl-singers">' + singerNames + '</div>' : '') +
+        (g.notes ? '<div class="sched-tl-notes">' + TSEB.util.esc(g.notes) + '</div>' : '') +
+      '</div>' +
+      '</div>';
+  },
+
+  // ============================================================
+  // MAP VIEW
+  // ============================================================
+  _mapHTML: function() {
+    var todayD = new Date();
+    todayD.setHours(0, 0, 0, 0);
+    var list = this._data.filter(function(g) {
+      var dt = new Date(g.gig_date + 'T00:00:00');
+      return dt >= todayD;
+    }).slice(0, 6);
+
+    var html = '<div class="sched-map-head">' +
+      '<div class="eyebrow sched-map-eyebrow">Schedule &middot; Map</div>' +
+      '<h2 class="sched-map-title">Gigs on the map</h2>' +
+      '</div>' +
+      '<div id="sched-map-canvas" class="sched-map-canvas"></div>';
+
+    if (!list.length) {
+      html += '<div class="empty-state">' +
+        '<div class="empty-state-title">No upcoming gigs</div>' +
+        '<div class="empty-state-body">Tap + to schedule one.</div>' +
+        '</div>';
+      return html;
+    }
+
+    html += '<div class="sched-tl-list">' +
+      list.map(function(g, i) { return TSEB.schedule._timelineRow(g, i + 1); }).join('') +
+      '</div>';
+
+    return html;
+  },
+
+  _initMap: function() {
+    var el = document.getElementById('sched-map-canvas');
+    if (!el || typeof L === 'undefined') return;
+
+    if (this._map) {
+      try { this._map.remove(); } catch (e) {}
+      this._map = null;
+    }
+
+    var todayD = new Date();
+    todayD.setHours(0, 0, 0, 0);
+    var list = this._data.filter(function(g) {
+      var dt = new Date(g.gig_date + 'T00:00:00');
+      return dt >= todayD;
+    }).slice(0, 6);
+
+    var map = L.map(el, { zoomControl: false, attributionControl: true }).setView([37.84, -122.26], 11);
+    L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
+      attribution: '&copy; OSM, &copy; CartoDB',
+      subdomains: 'abcd',
+      maxZoom: 19
+    }).addTo(map);
+
+    var bounds = [];
+    list.forEach(function(g, i) {
+      var zip = g.institution && g.institution.zip_code;
+      var c = zip && TSEB.schedule._zipCoords[zip];
+      if (!c) return;
+      // Jitter overlapping pins so multiple gigs in same zip stay distinguishable.
+      var jitter = 0.004 * (i % 4);
+      var lat = c.lat + jitter * (i % 2 === 0 ? 1 : -1);
+      var lng = c.lng + jitter * (i % 2 === 0 ? -1 : 1);
+      var dt = new Date(g.gig_date + 'T00:00:00');
+      var dateStr = dt.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+      var html = '<div class="tseb-pin-inner"><span class="n">' + (i + 1) + '</span><span class="d">' + TSEB.util.esc(dateStr) + '</span></div>';
+      var icon = L.divIcon({ className: 'tseb-pin', html: html, iconSize: [null, null], iconAnchor: [22, 14] });
+      var m = L.marker([lat, lng], { icon: icon }).addTo(map);
+      m.on('click', function() { TSEB.schedule.showGigDetail(g.id); });
+      bounds.push([lat, lng]);
+    });
+
+    if (bounds.length) {
+      try { map.fitBounds(bounds, { padding: [30, 30], maxZoom: 13 }); } catch (e) {}
+    }
+
+    this._map = map;
+    setTimeout(function() { try { map.invalidateSize(); } catch (e) {} }, 100);
+  },
+
+  // ============================================================
+  // ADD / EDIT / DETAIL — manuscript style
   // ============================================================
   async openAddForm() {
-    // Need institution list for venue dropdown
     var { data: institutions } = await TSEB.sb.from('institutions')
       .select('id, name, status')
-      .eq('status', 'active')
+      .in('status', ['active', 'site_visit', 'in_conversation'])
       .order('name');
 
-    var instOptions = '<option value="">Select venue...</option>' +
+    var instOptions = '<option value="">Select venue&hellip;</option>' +
       (institutions || []).map(function(i) {
         return '<option value="' + i.id + '">' + TSEB.util.esc(i.name) + '</option>';
       }).join('');
 
-    var singerOptions = '<option value="">Select singer...</option>' +
+    var singerOptions = '<option value="">&mdash;</option>' +
       TSEB.singersCache.map(function(s) {
         return '<option value="' + s.id + '">' + TSEB.util.esc(s.first_name) + '</option>';
       }).join('');
 
+    var today = TSEB.util.todayStr();
+
     var html =
-      '<div class="modal-header">' +
-      '<button class="modal-back-btn" onclick="TSEB.closeForm()" aria-label="Cancel">&#8592;</button>' +
-      '<div class="modal-title">Add Singing Session</div>' +
+      '<form id="add-gig-form" onsubmit="event.preventDefault(); TSEB.schedule.submitAdd(this);" style="display:flex; flex-direction:column; height:100%;">' +
+      '<div class="form-topbar">' +
+        '<button type="button" class="topbar-link" onclick="TSEB.closeForm()">Cancel</button>' +
+        '<button type="submit" class="topbar-link topbar-link-accent">Save</button>' +
       '</div>' +
-      '<div class="modal-body">' +
-      '<form id="add-gig-form" onsubmit="event.preventDefault(); TSEB.schedule.submitAdd(this);">' +
+      '<div class="form-body" style="overflow-y:auto; flex:1;">' +
+        '<div class="eyebrow">Scheduling a gig</div>' +
+        '<h1 class="form-title">New singing session</h1>' +
 
-      '<div class="form-group">' +
-      '<label class="form-label">Venue</label>' +
-      '<select name="institution_id" class="form-input form-select" required>' + instOptions + '</select>' +
+        '<label class="eyebrow form-eyebrow-label">Venue</label>' +
+        '<select name="institution_id" class="form-input form-select form-input-italic" required>' + instOptions + '</select>' +
+
+        '<label class="eyebrow form-eyebrow-label">Date</label>' +
+        '<input type="date" name="gig_date" class="form-input form-input-italic" value="' + today + '" required>' +
+
+        '<label class="eyebrow form-eyebrow-label">Time</label>' +
+        '<input type="time" name="gig_time" class="form-input form-input-italic">' +
+
+        '<label class="eyebrow form-eyebrow-label">Recurrence</label>' +
+        '<select name="recurrence" class="form-input form-select form-input-italic">' +
+          '<option value="one_time">One-time</option>' +
+          '<option value="weekly">Weekly</option>' +
+          '<option value="biweekly">Biweekly</option>' +
+          '<option value="2x_month">2x per month</option>' +
+          '<option value="monthly">Monthly</option>' +
+        '</select>' +
+
+        '<label class="eyebrow form-eyebrow-label">Singer 1 (anchor)</label>' +
+        '<select name="singer1" class="form-input form-select form-input-italic">' + singerOptions + '</select>' +
+
+        '<label class="eyebrow form-eyebrow-label">Singer 2</label>' +
+        '<select name="singer2" class="form-input form-select form-input-italic">' + singerOptions + '</select>' +
+
+        '<label class="eyebrow form-eyebrow-label">Singer 3</label>' +
+        '<select name="singer3" class="form-input form-select form-input-italic">' + singerOptions + '</select>' +
+
+        '<label class="eyebrow form-eyebrow-label">Notes</label>' +
+        '<textarea name="gig_notes" class="form-input form-input-italic" rows="3" placeholder="Anything special&hellip;"></textarea>' +
       '</div>' +
-
-      '<div class="form-group">' +
-      '<label class="form-label">Date</label>' +
-      '<input type="date" name="gig_date" class="form-input" required>' +
-      '</div>' +
-
-      '<div class="form-group">' +
-      '<label class="form-label">Time</label>' +
-      '<input type="time" name="gig_time" class="form-input">' +
-      '</div>' +
-
-      '<div class="form-group">' +
-      '<label class="form-label">Recurrence</label>' +
-      '<select name="recurrence" class="form-input form-select">' +
-      '<option value="one_time">One-time</option>' +
-      '<option value="weekly">Weekly</option>' +
-      '<option value="biweekly">Biweekly</option>' +
-      '<option value="2x_month">2x per month</option>' +
-      '<option value="monthly">Monthly</option>' +
-      '</select>' +
-      '</div>' +
-
-      '<div class="form-group">' +
-      '<label class="form-label">Singer 1 (anchor)</label>' +
-      '<select name="singer1" class="form-input form-select">' + singerOptions + '</select>' +
-      '</div>' +
-
-      '<div class="form-group">' +
-      '<label class="form-label">Singer 2</label>' +
-      '<select name="singer2" class="form-input form-select">' + singerOptions + '</select>' +
-      '</div>' +
-
-      '<div class="form-group">' +
-      '<label class="form-label">Singer 3</label>' +
-      '<select name="singer3" class="form-input form-select">' + singerOptions + '</select>' +
-      '</div>' +
-
-      '<div class="form-group">' +
-      '<label class="form-label">Notes</label>' +
-      '<textarea name="gig_notes" class="form-input" rows="3" placeholder="Any special notes..."></textarea>' +
-      '</div>' +
-
-      '<button type="submit" class="btn btn-primary" style="width:100%; margin-top:8px;">Schedule Gig</button>' +
-      '</form>' +
-      '</div>';
+      '</form>';
 
     TSEB.showForm(html);
   },
@@ -301,7 +467,6 @@ TSEB.schedule = {
 
     if (error) { TSEB.toast('Error: ' + error.message, 'error'); return; }
 
-    // Add singers
     var singerIds = [fd.get('singer1'), fd.get('singer2'), fd.get('singer3')].filter(Boolean);
     if (singerIds.length && gig) {
       await TSEB.sb.from('gig_singers').insert(
@@ -312,24 +477,21 @@ TSEB.schedule = {
     }
 
     TSEB.closeForm();
-    TSEB.toast('Singing session scheduled!', 'success');
+    TSEB.toast('Singing session scheduled', 'success');
     this._loaded = false;
     this.load();
   },
 
-  // ============================================================
-  // GIG DETAIL
-  // ============================================================
   async showGigDetail(gigId) {
-    TSEB.showDetail('<div class="modal-header"><div class="modal-title">Loading...</div></div>');
+    TSEB.showDetail('<div class="detail-topbar"><span class="topbar-link">&larr; Schedule</span></div><div class="detail-body"><div class="detail-eyebrow">Loading&hellip;</div></div>');
 
     var { data: gig, error } = await TSEB.sb.from('gigs')
-      .select('*, institution:institutions(id, name, address, institution_type, contacts(first_name, last_name, job_title, phone, email, is_primary)), gig_singers(singer_id, is_anchor)')
+      .select('*, institution:institutions(id, name, address, zip_code, institution_type, contacts(first_name, last_name, job_title, phone, email, is_primary)), gig_singers(singer_id, is_anchor)')
       .eq('id', gigId).single();
 
     if (error || !gig) {
       TSEB.closeDetail();
-      TSEB.toast('Could not load gig details', 'error');
+      TSEB.toast('Could not load gig', 'error');
       return;
     }
 
@@ -337,148 +499,149 @@ TSEB.schedule = {
     var dt = new Date(gig.gig_date + 'T00:00:00');
     var dateLabel = dt.toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' });
     var timeStr = gig.gig_time ? TSEB.util.fmtTime(gig.gig_time) : '';
+    var rec = TSEB.util.recurrenceLabel(gig.recurrence) || '';
+    var monthShort = dt.toLocaleDateString('en-US', { month: 'short' });
+    var day = dt.getDate();
+    var dow = dt.toLocaleDateString('en-US', { weekday: 'long' });
 
     var contacts = ((inst.contacts || []).slice().sort(function(a, b) {
       return (b.is_primary ? 1 : 0) - (a.is_primary ? 1 : 0);
     }));
 
-    var singers = (gig.gig_singers || []).map(function(gs) {
+    var singerNames = (gig.gig_singers || []).map(function(gs) {
       var name = TSEB.util.singerName(gs.singer_id);
-      return gs.is_anchor
-        ? '<span class="singer-chip">' + TSEB.util.esc(name) + ' <span style="font-size:11px; opacity:.7;">anchor</span></span>'
-        : TSEB.util.singerChip(name);
+      return gs.is_anchor ? name + ' (anchor)' : name;
     });
 
     var contactsHTML = '';
     if (contacts.length) {
-      contactsHTML = '<div style="margin-bottom:20px;">' +
-        '<h4 style="font-size:14px; font-weight:700; text-transform:uppercase; letter-spacing:.06em; color:var(--muted); margin-bottom:10px;">Contacts</h4>' +
+      contactsHTML = '<div class="detail-section">' +
+        '<div class="detail-section-head"><span class="eyebrow">Contacts</span></div>' +
         contacts.map(function(c) {
-          return '<div style="background:var(--bg); border:1px solid var(--border); border-radius:var(--radius-sm); padding:12px; margin-bottom:8px;">' +
-            '<div style="font-weight:600;">' + TSEB.util.esc(((c.first_name || '') + ' ' + (c.last_name || '')).trim()) +
-            (c.is_primary ? ' <span style="font-size:11px; color:var(--accent); font-weight:700;">PRIMARY</span>' : '') + '</div>' +
-            (c.job_title ? '<div style="font-size:14px; color:var(--muted);">' + TSEB.util.esc(c.job_title) + '</div>' : '') +
-            '<div style="font-size:14px; margin-top:4px;">' +
-            (c.phone ? '<a href="tel:' + TSEB.util.esc(c.phone) + '" style="color:var(--primary);">' + TSEB.util.esc(c.phone) + '</a>' : '') +
-            (c.phone && c.email ? ' · ' : '') +
-            (c.email ? '<a href="mailto:' + TSEB.util.esc(c.email) + '" style="color:var(--primary);">' + TSEB.util.esc(c.email) + '</a>' : '') +
-            '</div></div>';
+          var name = ((c.first_name || '') + ' ' + (c.last_name || '')).trim() || 'Contact';
+          return '<div class="detail-contact-row">' +
+            '<div class="detail-contact-name">' + TSEB.util.esc(name) +
+              (c.is_primary ? ' <span class="smcaps faint" style="font-size:9px;">primary</span>' : '') +
+            '</div>' +
+            (c.job_title ? '<div class="detail-contact-meta">' + TSEB.util.esc(c.job_title) + '</div>' : '') +
+            (c.phone ? '<a class="detail-contact-phone" href="tel:' + TSEB.util.esc(c.phone) + '">' + TSEB.util.esc(c.phone) + '</a>' : '') +
+            (c.email ? '<a class="detail-contact-email" href="mailto:' + TSEB.util.esc(c.email) + '">' + TSEB.util.esc(c.email) + '</a>' : '') +
+            '</div>';
         }).join('') +
         '</div>';
     }
 
+    var meta = (timeStr ? timeStr : '') +
+      (timeStr && rec ? ' &middot; ' : '') +
+      (rec ? rec : '');
+
     var html =
-      '<div class="modal-header">' +
-      '<button class="modal-back-btn" onclick="TSEB.closeDetail()" aria-label="Close">&#8592;</button>' +
-      '<div class="modal-title">' + TSEB.util.esc(inst.name || 'Gig Detail') + '</div>' +
+      '<div class="detail-topbar">' +
+        '<button type="button" class="topbar-link" onclick="TSEB.closeDetail()">&larr; Schedule</button>' +
+        '<button type="button" class="topbar-link topbar-link-accent" onclick="TSEB.schedule.openEditForm(\'' + gig.id + '\')">Edit</button>' +
       '</div>' +
-      '<div class="modal-body">' +
+      '<div class="detail-body">' +
+        '<div class="detail-hero">' +
+          '<div class="detail-eyebrow">Singing at</div>' +
+          '<h1 class="detail-title">' + TSEB.util.esc(inst.name || 'Gig') + '</h1>' +
+        '</div>' +
 
-      '<div style="margin-bottom:20px;">' +
-      '<div style="font-family:var(--font-display); font-size:20px; font-weight:600; margin-bottom:4px;">' + TSEB.util.esc(dateLabel) + '</div>' +
-      '<div style="font-size:16px; color:var(--muted);">' +
-      (timeStr ? timeStr + ' · ' : '') +
-      TSEB.util.recurrenceLabel(gig.recurrence) +
-      '</div>' +
-      (inst.address ? '<div style="font-size:15px; color:var(--muted); margin-top:4px;">' + TSEB.util.esc(inst.address) + '</div>' : '') +
-      '</div>' +
+        '<div class="sched-tl-list" style="padding:0; margin-bottom:18px;">' +
+          '<div class="sched-tl-row" style="cursor:default; padding-bottom:0;">' +
+            '<div class="sched-tl-date">' +
+              '<div class="sched-tl-month">' + TSEB.util.esc(monthShort) + '</div>' +
+              '<div class="sched-tl-day">' + day + '</div>' +
+              '<div class="sched-tl-dow">' + TSEB.util.esc(dow) + '</div>' +
+            '</div>' +
+            '<div class="sched-tl-rule" style="margin-bottom:0;"></div>' +
+            '<div class="sched-tl-body">' +
+              '<div class="sched-tl-venue">' + TSEB.util.esc(dateLabel) + '</div>' +
+              (meta ? '<div class="sched-tl-meta">' + meta + '</div>' : '') +
+              (inst.address ? '<div class="sched-tl-singers" style="font-size:13px;">' + TSEB.util.esc(inst.address) + (inst.zip_code ? ' &middot; ' + TSEB.util.esc(inst.zip_code) : '') + '</div>' : '') +
+            '</div>' +
+          '</div>' +
+        '</div>' +
 
-      (singers.length
-        ? '<div style="margin-bottom:20px;"><h4 style="font-size:14px; font-weight:700; text-transform:uppercase; letter-spacing:.06em; color:var(--muted); margin-bottom:10px;">Singers</h4>' +
-          '<div style="display:flex; flex-wrap:wrap; gap:6px;">' + singers.join('') + '</div></div>'
-        : '') +
+        (singerNames.length
+          ? '<div class="detail-section"><div class="detail-section-head"><span class="eyebrow">Singers</span></div>' +
+            '<div class="sched-tl-singers" style="padding:0 4px;">' + TSEB.util.esc(singerNames.join(' · ')) + '</div></div>'
+          : '<div class="detail-section"><div class="detail-section-head"><span class="eyebrow">Singers</span></div><div class="detail-empty">No singers assigned yet</div></div>') +
 
-      contactsHTML +
+        contactsHTML +
 
-      (gig.notes
-        ? '<div style="margin-bottom:20px;"><h4 style="font-size:14px; font-weight:700; text-transform:uppercase; letter-spacing:.06em; color:var(--muted); margin-bottom:10px;">Notes</h4><p style="font-size:15px;">' + TSEB.util.esc(gig.notes) + '</p></div>'
-        : '') +
+        (gig.notes
+          ? '<div class="detail-section"><div class="detail-section-head"><span class="eyebrow">Notes</span></div>' +
+            '<div class="detail-notes">' + TSEB.util.esc(gig.notes) + '</div></div>'
+          : '') +
 
-      '<div style="display:flex; gap:10px; margin-top:20px;">' +
-      '<button class="btn btn-primary" style="flex:1;" onclick="TSEB.schedule.openEditForm(\'' + gig.id + '\')">Edit Gig</button>' +
-      (inst.id
-        ? '<button class="btn btn-secondary" style="flex:1;" onclick="TSEB.outreach.showDetail(\'' + inst.id + '\')">View Facility</button>'
-        : '') +
-      '</div>' +
-
+        (inst.id
+          ? '<div style="margin-top:24px;"><button class="btn btn-accent" style="width:100%;" onclick="TSEB.outreach.showDetail(\'' + inst.id + '\')">Open facility</button></div>'
+          : '') +
       '</div>';
 
     TSEB.showDetail(html);
   },
 
-  // ============================================================
-  // EDIT GIG
-  // ============================================================
   async openEditForm(gigId) {
     var { data: gig } = await TSEB.sb.from('gigs').select('*').eq('id', gigId).single();
     if (!gig) { TSEB.toast('Could not load gig', 'error'); return; }
 
     TSEB.closeDetail();
 
-    var singerOptions = '<option value="">Select singer...</option>' +
+    var singerOptions = '<option value="">&mdash;</option>' +
       TSEB.singersCache.map(function(s) {
         return '<option value="' + s.id + '">' + TSEB.util.esc(s.first_name) + '</option>';
       }).join('');
 
-    // Get current singers
-    var { data: currentSingers } = await TSEB.sb.from('gig_singers').select('singer_id, is_anchor').eq('gig_id', gigId).order('is_anchor', { ascending: false });
+    var { data: currentSingers } = await TSEB.sb.from('gig_singers')
+      .select('singer_id, is_anchor')
+      .eq('gig_id', gigId)
+      .order('is_anchor', { ascending: false });
     var cs = currentSingers || [];
 
-    TSEB.showForm(
-      '<div class="modal-header">' +
-      '<button class="modal-back-btn" onclick="TSEB.closeForm(); TSEB.schedule.showGigDetail(\'' + gigId + '\')" aria-label="Back">&#8592;</button>' +
-      '<div class="modal-title">Edit Gig</div>' +
+    var rec = gig.recurrence || 'one_time';
+
+    var html =
+      '<form onsubmit="event.preventDefault(); TSEB.schedule.submitEdit(this, \'' + gigId + '\');" style="display:flex; flex-direction:column; height:100%;">' +
+      '<div class="form-topbar">' +
+        '<button type="button" class="topbar-link" onclick="TSEB.closeForm(); TSEB.schedule.showGigDetail(\'' + gigId + '\')">Cancel</button>' +
+        '<button type="submit" class="topbar-link topbar-link-accent">Save</button>' +
       '</div>' +
-      '<div class="modal-body">' +
-      '<form onsubmit="event.preventDefault(); TSEB.schedule.submitEdit(this, \'' + gigId + '\');">' +
+      '<div class="form-body" style="overflow-y:auto; flex:1;">' +
+        '<div class="eyebrow">Editing gig</div>' +
+        '<h1 class="form-title">Edit singing session</h1>' +
 
-      '<div class="form-group">' +
-      '<label class="form-label">Date</label>' +
-      '<input type="date" name="gig_date" class="form-input" required value="' + (gig.gig_date || '') + '">' +
+        '<label class="eyebrow form-eyebrow-label">Date</label>' +
+        '<input type="date" name="gig_date" class="form-input form-input-italic" required value="' + (gig.gig_date || '') + '">' +
+
+        '<label class="eyebrow form-eyebrow-label">Time</label>' +
+        '<input type="time" name="gig_time" class="form-input form-input-italic" value="' + (gig.gig_time ? gig.gig_time.slice(0, 5) : '') + '">' +
+
+        '<label class="eyebrow form-eyebrow-label">Recurrence</label>' +
+        '<select name="recurrence" class="form-input form-select form-input-italic">' +
+          '<option value="one_time"' + (rec === 'one_time' ? ' selected' : '') + '>One-time</option>' +
+          '<option value="weekly"' + (rec === 'weekly' ? ' selected' : '') + '>Weekly</option>' +
+          '<option value="biweekly"' + (rec === 'biweekly' ? ' selected' : '') + '>Biweekly</option>' +
+          '<option value="2x_month"' + (rec === '2x_month' ? ' selected' : '') + '>2x per month</option>' +
+          '<option value="monthly"' + (rec === 'monthly' ? ' selected' : '') + '>Monthly</option>' +
+        '</select>' +
+
+        '<label class="eyebrow form-eyebrow-label">Singer 1 (anchor)</label>' +
+        '<select name="singer1" class="form-input form-select form-input-italic">' + singerOptions + '</select>' +
+
+        '<label class="eyebrow form-eyebrow-label">Singer 2</label>' +
+        '<select name="singer2" class="form-input form-select form-input-italic">' + singerOptions + '</select>' +
+
+        '<label class="eyebrow form-eyebrow-label">Singer 3</label>' +
+        '<select name="singer3" class="form-input form-select form-input-italic">' + singerOptions + '</select>' +
+
+        '<label class="eyebrow form-eyebrow-label">Notes</label>' +
+        '<textarea name="gig_notes" class="form-input form-input-italic" rows="3">' + TSEB.util.esc(gig.notes || '') + '</textarea>' +
       '</div>' +
+      '</form>';
 
-      '<div class="form-group">' +
-      '<label class="form-label">Time</label>' +
-      '<input type="time" name="gig_time" class="form-input" value="' + (gig.gig_time ? gig.gig_time.slice(0, 5) : '') + '">' +
-      '</div>' +
+    TSEB.showForm(html);
 
-      '<div class="form-group">' +
-      '<label class="form-label">Recurrence</label>' +
-      '<select name="recurrence" class="form-input form-select">' +
-      '<option value="one_time"' + (gig.recurrence === 'one_time' ? ' selected' : '') + '>One-time</option>' +
-      '<option value="weekly"' + (gig.recurrence === 'weekly' ? ' selected' : '') + '>Weekly</option>' +
-      '<option value="biweekly"' + (gig.recurrence === 'biweekly' ? ' selected' : '') + '>Biweekly</option>' +
-      '<option value="2x_month"' + (gig.recurrence === '2x_month' ? ' selected' : '') + '>2x per month</option>' +
-      '<option value="monthly"' + (gig.recurrence === 'monthly' ? ' selected' : '') + '>Monthly</option>' +
-      '</select>' +
-      '</div>' +
-
-      '<div class="form-group">' +
-      '<label class="form-label">Singer 1 (anchor)</label>' +
-      '<select name="singer1" class="form-input form-select">' + singerOptions + '</select>' +
-      '</div>' +
-
-      '<div class="form-group">' +
-      '<label class="form-label">Singer 2</label>' +
-      '<select name="singer2" class="form-input form-select">' + singerOptions + '</select>' +
-      '</div>' +
-
-      '<div class="form-group">' +
-      '<label class="form-label">Singer 3</label>' +
-      '<select name="singer3" class="form-input form-select">' + singerOptions + '</select>' +
-      '</div>' +
-
-      '<div class="form-group">' +
-      '<label class="form-label">Notes</label>' +
-      '<textarea name="gig_notes" class="form-input" rows="3">' + TSEB.util.esc(gig.notes || '') + '</textarea>' +
-      '</div>' +
-
-      '<button type="submit" class="btn btn-primary" style="width:100%; margin-top:8px;">Save Changes</button>' +
-      '</form>' +
-      '</div>'
-    );
-
-    // Pre-select current singers after form renders
     setTimeout(function() {
       var form = document.getElementById('form-container');
       if (!form) return;
@@ -501,7 +664,6 @@ TSEB.schedule = {
 
     if (error) { TSEB.toast('Error: ' + error.message, 'error'); return; }
 
-    // Replace singers: delete existing, insert new
     await TSEB.sb.from('gig_singers').delete().eq('gig_id', gigId);
     var singerIds = [fd.get('singer1'), fd.get('singer2'), fd.get('singer3')].filter(Boolean);
     if (singerIds.length) {
@@ -513,7 +675,7 @@ TSEB.schedule = {
     }
 
     TSEB.closeForm();
-    TSEB.toast('Gig updated!', 'success');
+    TSEB.toast('Gig updated', 'success');
     this._loaded = false;
     this.load();
   }


### PR DESCRIPTION
## Summary

Third PR in the Plainchant manuscript redesign. Stacked on the Outreach branch.

The Schedule screen now offers three views, with the user's choice
remembered in `localStorage` as `tseb-schedule-view`:

- **Calendar** — month grid with italic display numerals, today highlighted
  with an accent box, ochre dots under days that have gigs. An "Upcoming
  gigs" list under the grid mirrors the visual language used elsewhere.
- **Agenda** — vertical timeline. Big italic display day numerals on the
  left, ochre vertical rule with dots, venue / time / recurrence /
  singers / notes per row.
- **Map** — Leaflet with CartoDB Light tiles and custom italic-numeral
  divIcon pins. Pins jitter when stacked in the same zip code. A numbered
  timeline list below the map mirrors the pin numbers.

Restyled the gig detail screen and the Add / Edit gig forms to the
manuscript pattern (form-topbar with Cancel/Save smcaps, eyebrow + italic
display title, italic input fields, ochre full-width CTA).

Bumped `.modal-overlay` z-index to 1000 so detail/form modals layer above
Leaflet's marker pane (z-index 600).

## Test plan

- [ ] Navigate to Schedule — picker shows Calendar / Agenda / Map; default Calendar
- [ ] Tap Agenda — timeline rendering, view persists across reloads
- [ ] Tap Map — Leaflet map renders with CartoDB Light tiles, pins clickable
- [ ] Tap a calendar day with a dot — opens gig detail
- [ ] Tap upcoming row / agenda row / map pin — opens gig detail
- [ ] Edit a gig — manuscript-style form with italic fields and Cancel/Save
- [ ] Add a gig — venue dropdown, today's date prefilled, Save creates gig

🤖 Generated with [Claude Code](https://claude.com/claude-code)