### PR TITLE
Fix Schedule: render views even when no upcoming gigs

### DIFF
--- a/js/schedule.js
+++ b/js/schedule.js
@@ -66,17 +66,9 @@ TSEB.schedule = {
     var el = document.getElementById('schedule-list');
     if (!el) return;
 
+    if (!this._data) this._data = [];
+
     var picker = this._pickerHTML();
-
-    if (!this._data || this._data.length === 0) {
-      el.innerHTML = picker +
-        '<div class="empty-state">' +
-        '<div class="empty-state-title">No upcoming gigs</div>' +
-        '<div class="empty-state-body">No singing sessions scheduled yet. Tap + to add a gig.</div>' +
-        '</div>';
-      return;
-    }
-
     var body = '';
     if (this._view === 'agenda') body = this._agendaHTML();
     else if (this._view === 'map') body = this._mapHTML();


### PR DESCRIPTION
Calendar should always show the month grid so the user can navigate to past months. Agenda and Map already render their own empty states; the early return was redundant and hid all three views.